### PR TITLE
build: don't use -buildmode=pie

### DIFF
--- a/build
+++ b/build
@@ -14,4 +14,4 @@ if [ -z ${BIN_PATH+a} ]; then
 fi
 
 echo "Building $NAME..."
-go build -buildmode=pie -o ${BIN_PATH}/${NAME} internal/main.go
+go build -o ${BIN_PATH}/${NAME} internal/main.go


### PR DESCRIPTION
This isn't needed and breaks without cgo enabled.