### PR TITLE
config/v1_0/fcos.go: don't unconditionally print newline

### DIFF
--- a/config/v1_0/fcos.go
+++ b/config/v1_0/fcos.go
@@ -83,7 +83,7 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, erro
 	second := validate.Validate(final, "json")
 	second.Correlate(translatedTree)
 	r.Merge(second)
-	fmt.Println(r.String())
+	fmt.Print(r.String())
 
 	if r.IsFatal() {
 		return nil, ErrInvalidConfig


### PR DESCRIPTION
Use `fmt.Print()` instead of `fmt.Println()` to print the report. The
`String()` method already adds a newline at the end of each report
entry.

My main motivation for doing this though is a super tiny polish item:
even `fcct` invocations fed perfectly valid YAML would still print an
empty line:

```
$ fcct -input basic.yaml -output basic.json

$
```