### PR TITLE
main: use O_TRUNC when opening output file

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -73,7 +73,7 @@ func main() {
 
 	if output != "" {
 		var err error
-		outfile, err = os.OpenFile(output, os.O_WRONLY|os.O_CREATE, 0644)
+		outfile, err = os.OpenFile(output, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0644)
 		if err != nil {
 			fail("failed to open %s: %v\n", output, err)
 		}


### PR DESCRIPTION
Ensure we're not just overwriting the first bit of the file but rather
are replacing it.

fixes https://github.com/coreos/fcct/issues/42