### PR TITLE
docs/getting-started.md: removed -t flag for podman run using stdin

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,7 +28,7 @@ This example uses podman, but docker can also be used. Substitute v0.2.0 with th
 podman pull quay.io/coreos/fcct:v0.2.0
 
 # Run fcct using standard in and standard out
-podman run -it --rm quay.io/coreos/fcct:v0.2.0 -pretty -strict < your_config.fcc > transpiled_config.ign
+podman run -i --rm quay.io/coreos/fcct:v0.2.0 -pretty -strict < your_config.fcc > transpiled_config.ign
 
 # Run fcct using files.
 podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:v0.2.0 -pretty -strict -input /config.fcc > transpiled_config.ign


### PR DESCRIPTION
As said in the [libpod doc](https://github.com/containers/libpod/blob/master/docs/podman-run.1.md)
> NOTE: The -t option is incompatible with a redirection of the podman client standard input.

If you leave the ```-t``` flag your_config.fcc content is sent to stdout and the prompt is waiting endlessly.