### PR TITLE
Fix line and column handling and propagation

### DIFF
--- a/base/v0_1/translate.go
+++ b/base/v0_1/translate.go
@@ -17,75 +17,85 @@ package v0_1
 import (
 	"net/url"
 
-	"github.com/coreos/ignition/v2/config/translate"
+	"github.com/coreos/fcct/translate"
+
 	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/vincent-petithory/dataurl"
 )
 
-func (c Config) ToIgn3_0() (types.Config, error) {
+// ToIgn3_0 translates the config to an Ignition config. It also returns the set of translations
+// it did so paths in the resultant config can be tracked back to their source in the source config.
+func (c Config) ToIgn3_0() (types.Config, translate.TranslationSet, error) {
 	ret := types.Config{}
-	tr := translate.NewTranslator()
+	tr := translate.NewTranslator("yaml", "json")
 	tr.AddCustomTranslator(translateIgnition)
 	tr.AddCustomTranslator(translateFile)
 	tr.AddCustomTranslator(translateDirectory)
 	tr.AddCustomTranslator(translateLink)
-	tr.Translate(&c, &ret)
-	return ret, nil
+	translations := tr.Translate(&c, &ret)
+	return ret, translations, nil
 }
 
-func translateIgnition(from Ignition) (to types.Ignition) {
-	tr := translate.NewTranslator()
+func translateIgnition(from Ignition) (to types.Ignition, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
 	to.Version = types.MaxVersion.String()
-	tr.Translate(&from.Config, &to.Config)
-	tr.Translate(&from.Security, &to.Security)
-	tr.Translate(&from.Timeouts, &to.Timeouts)
+	tm = tr.Translate(&from.Config, &to.Config).Prefix("config")
+	tm.MergeP("security", tr.Translate(&from.Security, &to.Security))
+	tm.MergeP("timeouts", tr.Translate(&from.Timeouts, &to.Timeouts))
 	return
 }
 
-func translateFile(from File) (to types.File) {
-	tr := translate.NewTranslator()
+func translateFile(from File) (to types.File, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
 	tr.AddCustomTranslator(translateFileContents)
-	tr.Translate(&from.Group, &to.Group)
-	tr.Translate(&from.User, &to.User)
-	tr.Translate(&from.Append, &to.Append)
-	tr.Translate(&from.Contents, &to.Contents)
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
+	tm.MergeP("append", tr.Translate(&from.Append, &to.Append))
+	tm.MergeP("contents", tr.Translate(&from.Contents, &to.Contents))
 	to.Overwrite = from.Overwrite
 	to.Path = from.Path
 	to.Mode = from.Mode
+	tm.AddIdentity("overwrite", "path", "mode")
 	return
 }
 
-func translateFileContents(from FileContents) (to types.FileContents) {
+func translateFileContents(from FileContents) (to types.FileContents, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Verification, &to.Verification).Prefix("verification")
 	to.Source = from.Source
 	to.Compression = from.Compression
-	to.Verification.Hash = from.Verification.Hash
+	tm.AddIdentity("source", "compression")
 	if from.Inline != nil {
 		src := (&url.URL{
 			Scheme: "data",
 			Opaque: "," + dataurl.EscapeString(*from.Inline),
 		}).String()
 		to.Source = &src
+		tm.AddTranslation(path.New("yaml", "inline"), path.New("json", "source"))
 	}
 	return
 }
 
-func translateDirectory(from Directory) (to types.Directory) {
-	tr := translate.NewTranslator()
-	tr.Translate(&from.Group, &to.Group)
-	tr.Translate(&from.User, &to.User)
+func translateDirectory(from Directory) (to types.Directory, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
 	to.Overwrite = from.Overwrite
 	to.Path = from.Path
 	to.Mode = from.Mode
+	tm.AddIdentity("overwrite", "path", "mode")
 	return
 }
 
-func translateLink(from Link) (to types.Link) {
-	tr := translate.NewTranslator()
-	tr.Translate(&from.Group, &to.Group)
-	tr.Translate(&from.User, &to.User)
+func translateLink(from Link) (to types.Link, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
 	to.Target = from.Target
 	to.Hard = from.Hard
 	to.Overwrite = from.Overwrite
 	to.Path = from.Path
+	tm.AddIdentity("target", "hard", "overwrite", "path")
 	return
 }

--- a/config/common/common_test.go
+++ b/config/common/common_test.go
@@ -15,13 +15,10 @@
 package common
 
 import (
-	"reflect"
 	"testing"
-
-	"github.com/coreos/vcontext/tree"
 )
 
-func TestCamel(t *testing.T) {
+func TestSnake(t *testing.T) {
 	tests := []struct {
 		in  string
 		out string
@@ -32,112 +29,22 @@ func TestCamel(t *testing.T) {
 			"foo",
 		},
 		{
-			"snake_case",
 			"snakeCase",
+			"snake_case",
 		},
 		{
-			"long_snake_case",
 			"longSnakeCase",
+			"long_snake_case",
 		},
 		{
-			"camelAlready",
-			"camelAlready",
+			"snake_already",
+			"snake_already",
 		},
 	}
 
 	for i, test := range tests {
-		if camel(test.in) != test.out {
-			t.Errorf("#%d: expected %q got %q", i, test.out, camel(test.in))
-		}
-	}
-}
-
-func TestToCamelCase(t *testing.T) {
-	tests := []struct {
-		in  tree.Node
-		out tree.Node
-	}{
-		{},
-		{
-			tree.Leaf{
-				Marker: tree.MarkerFromIndices(1, 2),
-			},
-			tree.Leaf{
-				Marker: tree.MarkerFromIndices(1, 2),
-			},
-		},
-		{
-			tree.MapNode{
-				Marker: tree.MarkerFromIndices(1, 2),
-				Children: map[string]tree.Node{
-					"foo_bar": tree.Leaf{
-						tree.MarkerFromIndices(3, 4),
-					},
-				},
-				Keys: map[string]tree.Leaf{
-					"foo_bar": tree.Leaf{
-						tree.MarkerFromIndices(3, 4),
-					},
-				},
-			},
-			tree.MapNode{
-				Marker: tree.MarkerFromIndices(1, 2),
-				Children: map[string]tree.Node{
-					"fooBar": tree.Leaf{
-						tree.MarkerFromIndices(3, 4),
-					},
-				},
-				Keys: map[string]tree.Leaf{
-					"fooBar": tree.Leaf{
-						tree.MarkerFromIndices(3, 4),
-					},
-				},
-			},
-		},
-		{
-			tree.SliceNode{
-				Marker: tree.MarkerFromIndices(5, 6),
-				Children: []tree.Node{
-					tree.MapNode{
-						Marker: tree.MarkerFromIndices(1, 2),
-						Children: map[string]tree.Node{
-							"foo_bar": tree.Leaf{
-								tree.MarkerFromIndices(3, 4),
-							},
-						},
-						Keys: map[string]tree.Leaf{
-							"foo_bar": tree.Leaf{
-								tree.MarkerFromIndices(3, 4),
-							},
-						},
-					},
-				},
-			},
-			tree.SliceNode{
-				Marker: tree.MarkerFromIndices(5, 6),
-				Children: []tree.Node{
-					tree.MapNode{
-						Marker: tree.MarkerFromIndices(1, 2),
-						Children: map[string]tree.Node{
-							"fooBar": tree.Leaf{
-								tree.MarkerFromIndices(3, 4),
-							},
-						},
-						Keys: map[string]tree.Leaf{
-							"fooBar": tree.Leaf{
-								tree.MarkerFromIndices(3, 4),
-							},
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for i, test := range tests {
-		actual := ToCamelCase(test.in)
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		if snake(test.in) != test.out {
+			t.Errorf("#%d: expected %q got %q", i, test.out, snake(test.in))
 		}
 	}
 }

--- a/config/v1_0/fcos.go
+++ b/config/v1_0/fcos.go
@@ -22,7 +22,6 @@ import (
 	"github.com/coreos/fcct/config/common"
 	fcos_0_1 "github.com/coreos/fcct/distro/fcos/v0_1"
 
-	"github.com/coreos/ignition/v2/config/v3_0"
 	"github.com/coreos/ignition/v2/config/v3_0/types"
 	ignvalidate "github.com/coreos/ignition/v2/config/validate"
 	"github.com/coreos/vcontext/path"
@@ -41,17 +40,17 @@ type Config struct {
 }
 
 func (c Config) Translate() (types.Config, error) {
-	base, err := c.Config.ToIgn3_0()
+	cfg, err := c.Config.ToIgn3_0()
 	if err != nil {
 		return types.Config{}, err
 	}
 
-	distro, err := c.Fcos.ToIgn3_0()
+	cfg, err = c.Fcos.ToIgn3_0(cfg)
 	if err != nil {
 		return types.Config{}, err
 	}
 
-	return v3_0.Merge(distro, base), nil
+	return cfg, nil
 }
 
 // TranslateBytes translates from a v1.0 fcc to a v3.0.0 Ignition config. It returns a report of any errors or

--- a/distro/fcos/v0_1/translate.go
+++ b/distro/fcos/v0_1/translate.go
@@ -18,10 +18,7 @@ import (
 	"github.com/coreos/ignition/v2/config/v3_0/types"
 )
 
-func (f Fcos) ToIgn3_0() (types.Config, error) {
-	return types.Config{
-		Ignition: types.Ignition{
-			Version: "3.0.0",
-		},
-	}, nil
+// ToIgn3_0 takes a config and merges in the distro specific bits.
+func (f Fcos) ToIgn3_0(in types.Config) (types.Config, error) {
+	return in, nil
 }

--- a/distro/fcos/v0_1/translate.go
+++ b/distro/fcos/v0_1/translate.go
@@ -15,10 +15,12 @@
 package fcos_0_1
 
 import (
+	"github.com/coreos/fcct/translate"
+
 	"github.com/coreos/ignition/v2/config/v3_0/types"
 )
 
 // ToIgn3_0 takes a config and merges in the distro specific bits.
-func (f Fcos) ToIgn3_0(in types.Config) (types.Config, error) {
-	return in, nil
+func (f Fcos) ToIgn3_0(in types.Config) (types.Config, translate.TranslationSet, error) {
+	return in, translate.TranslationSet{}, nil
 }

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/coreos/ignition/v2 v2.0.1
 	github.com/coreos/vcontext v0.0.0-20190605182717-e9c4ffaa1f6a
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/stretchr/testify v1.3.0
 	github.com/vincent-petithory/dataurl v0.0.0-20160330182126-9a301d65acbb
 	gopkg.in/yaml.v3 v3.0.0-20190502103701-55513cacd4ae
 )

--- a/translate/tests/pkga/types.go
+++ b/translate/tests/pkga/types.go
@@ -1,0 +1,36 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkga
+
+type Trivial struct {
+	A string
+	B int
+	C bool
+}
+
+type Nested struct {
+	D string
+	Trivial
+}
+
+type TrivialReordered struct {
+	B int
+	A string
+	C bool
+}
+
+type HasList struct {
+	L []Trivial
+}

--- a/translate/tests/pkgb/types.go
+++ b/translate/tests/pkgb/types.go
@@ -1,0 +1,37 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package pkgb
+
+type Trivial struct {
+	A string
+	B int
+	C bool
+}
+
+type Nested struct {
+	D string
+	Trivial
+}
+
+// note: struct ordering is different from pkga
+type TrivialReordered struct {
+	A string
+	B int
+	C bool
+}
+
+type HasList struct {
+	L []Nested
+}

--- a/translate/tests/readme.txt
+++ b/translate/tests/readme.txt
@@ -1,0 +1,3 @@
+Tests for this translator are in their own package since it needs to test
+translating from one package to another. This pattern should not be replicated
+in other places in the codebase

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -1,0 +1,187 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/coreos/ignition/v2/config/util"
+)
+
+/*
+ * This is an automatic translator that replace boilerplate code to copy one
+ * struct into a nearly identical struct in another package. To use it first
+ * call NewTranslator() to get a translator instance. This can then have
+ * additional translation rules (in the form of functions) to translate from
+ * types in one struct to the other. Those functions are in the form:
+ *     func(typeFromInputStruct) -> typeFromOutputStruct
+ * These can be closures that reference the translator as well. This allows for
+ * manually translating some fields but resuming automatic translation on the
+ * other fields through the Translator.Translate() function.
+ */
+
+// Returns if this type can be translated without a custom translator. Children or other
+// ancestors might require custom translators however
+func (t translator) translatable(t1, t2 reflect.Type) bool {
+	k1 := t1.Kind()
+	k2 := t2.Kind()
+	if k1 != k2 {
+		return false
+	}
+	switch {
+	case util.IsPrimitive(k1):
+		return true
+	case util.IsInvalidInConfig(k1):
+		panic(fmt.Sprintf("Encountered invalid kind %s in config. This is a bug, please file a report", k1))
+	case k1 == reflect.Ptr || k1 == reflect.Slice:
+		return t.translatable(t1.Elem(), t2.Elem()) || t.hasTranslator(t1.Elem(), t2.Elem())
+	case k1 == reflect.Struct:
+		return t.translatableStruct(t1, t2)
+	default:
+		panic(fmt.Sprintf("Encountered unknown kind %s in config. This is a bug, please file a report", k1))
+	}
+}
+
+// precondition: t1, t2 are both of Kind 'struct'
+func (t translator) translatableStruct(t1, t2 reflect.Type) bool {
+	if t1.NumField() != t2.NumField() || t1.Name() != t2.Name() {
+		return false
+	}
+	for i := 0; i < t1.NumField(); i++ {
+		t1f := t1.Field(i)
+		t2f, ok := t2.FieldByName(t1f.Name)
+
+		if !ok {
+			return false
+		}
+		if !t.translatable(t1f.Type, t2f.Type) && !t.hasTranslator(t1f.Type, t2f.Type) {
+			return false
+		}
+	}
+	return true
+}
+
+// checks that t could reasonably be the type of a translator function
+func couldBeValidTranslator(t reflect.Type) bool {
+	if t.Kind() != reflect.Func {
+		return false
+	}
+	if t.NumIn() != 1 || t.NumOut() != 1 {
+		return false
+	}
+	if util.IsInvalidInConfig(t.In(0).Kind()) || util.IsInvalidInConfig(t.Out(0).Kind()) {
+		return false
+	}
+	return true
+}
+
+// translate from one type to another, but deep copy all data
+// precondition: vFrom and vTo are the same type as defined by translatable()
+// precondition: vTo is addressable and settable
+func (t translator) translateSameType(vFrom, vTo reflect.Value) {
+	k := vFrom.Kind()
+	switch {
+	case util.IsPrimitive(k):
+		// Use convert, even if not needed; type alias to primitives are not
+		// directly assignable and calling Convert on primitives does no harm
+		vTo.Set(vFrom.Convert(vTo.Type()))
+	case k == reflect.Ptr:
+		if vFrom.IsNil() {
+			return
+		}
+		vTo.Set(reflect.New(vTo.Type().Elem()))
+		t.translate(vFrom.Elem(), vTo.Elem())
+	case k == reflect.Slice:
+		if vFrom.IsNil() {
+			return
+		}
+		vTo.Set(reflect.MakeSlice(vTo.Type(), vFrom.Len(), vFrom.Len()))
+		for i := 0; i < vFrom.Len(); i++ {
+			t.translate(vFrom.Index(i), vTo.Index(i))
+		}
+	case k == reflect.Struct:
+		for i := 0; i < vFrom.NumField(); i++ {
+			t.translate(vFrom.Field(i), vTo.FieldByName(vFrom.Type().Field(i).Name))
+		}
+	default:
+		panic("Encountered types that are not the same when they should be. This is a bug, please file a report")
+	}
+}
+
+// helper to return if a custom translator was defined
+func (t translator) hasTranslator(tFrom, tTo reflect.Type) bool {
+	return t.getTranslator(tFrom, tTo).IsValid()
+}
+
+// vTo must be addressable, should be acquired by calling reflect.ValueOf() on a variable of the correct type
+func (t translator) translate(vFrom, vTo reflect.Value) {
+	tFrom := vFrom.Type()
+	tTo := vTo.Type()
+	if fnv := t.getTranslator(tFrom, tTo); fnv.IsValid() {
+		vTo.Set(fnv.Call([]reflect.Value{vFrom})[0])
+		return
+	}
+	if t.translatable(tFrom, tTo) {
+		t.translateSameType(vFrom, vTo)
+		return
+	}
+
+	panic(fmt.Sprintf("Translator not defined for %v to %v", tFrom, tTo))
+}
+
+type Translator interface {
+	AddCustomTranslator(t interface{})
+	Translate(from, to interface{})
+}
+
+func NewTranslator() Translator {
+	return &translator{}
+}
+
+type translator struct {
+	// List of custom translation funcs, must pass couldBeValidTranslator
+	// This is only for fields that cannot or should not be trivially translated,
+	// All trivially translated fields use the default behavior.
+	translators []reflect.Value
+}
+
+func (t *translator) AddCustomTranslator(fn interface{}) {
+	fnv := reflect.ValueOf(fn)
+	if !couldBeValidTranslator(fnv.Type()) {
+		panic("Tried to register invalid translator function")
+	}
+	t.translators = append(t.translators, fnv)
+}
+
+func (t translator) getTranslator(from, to reflect.Type) reflect.Value {
+	for _, fn := range t.translators {
+		if fn.Type().In(0) == from && fn.Type().Out(0) == to {
+			return fn
+		}
+	}
+	return reflect.Value{}
+}
+
+func (t translator) Translate(from, to interface{}) {
+	fv := reflect.ValueOf(from)
+	tv := reflect.ValueOf(to)
+	if fv.Kind() != reflect.Ptr || tv.Kind() != reflect.Ptr {
+		panic("Translate needs to be called on pointers")
+	}
+	fv = fv.Elem()
+	tv = tv.Elem()
+	t.translate(fv, tv)
+}

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -17,8 +17,10 @@ package translate
 import (
 	"fmt"
 	"reflect"
+	"strings"
 
 	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
 )
 
 /*
@@ -32,6 +34,10 @@ import (
  * manually translating some fields but resuming automatic translation on the
  * other fields through the Translator.Translate() function.
  */
+
+var (
+	translationsType = reflect.TypeOf(TranslationSet{})
+)
 
 // Returns if this type can be translated without a custom translator. Children or other
 // ancestors might require custom translators however
@@ -79,42 +85,69 @@ func couldBeValidTranslator(t reflect.Type) bool {
 	if t.Kind() != reflect.Func {
 		return false
 	}
-	if t.NumIn() != 1 || t.NumOut() != 1 {
+	if t.NumIn() != 1 || t.NumOut() != 2 {
 		return false
 	}
-	if util.IsInvalidInConfig(t.In(0).Kind()) || util.IsInvalidInConfig(t.Out(0).Kind()) {
+	if util.IsInvalidInConfig(t.In(0).Kind()) ||
+		util.IsInvalidInConfig(t.Out(0).Kind()) ||
+		t.Out(1) != translationsType {
 		return false
 	}
 	return true
 }
 
+// fieldName returns the name uses when (un)marshalling a field. t should be a reflect.Value of a struct,
+// index is the field index, and tag is the struct tag used when (un)marshalling (e.g. "json" or "yaml")
+func fieldName(t reflect.Value, index int, tag string) string {
+	f := t.Type().Field(index)
+	if tag == "" {
+		return f.Name
+	}
+	return strings.Split(f.Tag.Get(tag), ",")[0]
+}
+
 // translate from one type to another, but deep copy all data
 // precondition: vFrom and vTo are the same type as defined by translatable()
 // precondition: vTo is addressable and settable
-func (t translator) translateSameType(vFrom, vTo reflect.Value) {
+func (t translator) translateSameType(vFrom, vTo reflect.Value, fromPath, toPath path.ContextPath) {
 	k := vFrom.Kind()
 	switch {
 	case util.IsPrimitive(k):
 		// Use convert, even if not needed; type alias to primitives are not
 		// directly assignable and calling Convert on primitives does no harm
 		vTo.Set(vFrom.Convert(vTo.Type()))
+		t.translations.AddTranslation(fromPath, toPath)
 	case k == reflect.Ptr:
 		if vFrom.IsNil() {
 			return
 		}
 		vTo.Set(reflect.New(vTo.Type().Elem()))
-		t.translate(vFrom.Elem(), vTo.Elem())
+		t.translate(vFrom.Elem(), vTo.Elem(), fromPath, toPath)
 	case k == reflect.Slice:
 		if vFrom.IsNil() {
 			return
 		}
 		vTo.Set(reflect.MakeSlice(vTo.Type(), vFrom.Len(), vFrom.Len()))
 		for i := 0; i < vFrom.Len(); i++ {
-			t.translate(vFrom.Index(i), vTo.Index(i))
+			t.translate(vFrom.Index(i), vTo.Index(i), fromPath.Append(i), toPath.Append(i))
 		}
 	case k == reflect.Struct:
 		for i := 0; i < vFrom.NumField(); i++ {
-			t.translate(vFrom.Field(i), vTo.FieldByName(vFrom.Type().Field(i).Name))
+			fieldGoName := vFrom.Type().Field(i).Name
+			toStructField, ok := vTo.Type().FieldByName(fieldGoName)
+			if !ok {
+				panic("vTo did not have a matching type. This is a bug; please file a report")
+			}
+			toFieldIndex := toStructField.Index[0]
+			vToField := vTo.FieldByName(fieldGoName)
+
+			from := fromPath.Append(fieldName(vFrom, i, fromPath.Tag))
+			to := toPath.Append(fieldName(vTo, toFieldIndex, toPath.Tag))
+			if vFrom.Type().Field(i).Anonymous {
+				from = fromPath
+				to = toPath
+			}
+			t.translate(vFrom.Field(i), vToField, from, to)
 		}
 	default:
 		panic("Encountered types that are not the same when they should be. This is a bug, please file a report")
@@ -127,15 +160,24 @@ func (t translator) hasTranslator(tFrom, tTo reflect.Type) bool {
 }
 
 // vTo must be addressable, should be acquired by calling reflect.ValueOf() on a variable of the correct type
-func (t translator) translate(vFrom, vTo reflect.Value) {
+func (t translator) translate(vFrom, vTo reflect.Value, fromPath, toPath path.ContextPath) {
 	tFrom := vFrom.Type()
 	tTo := vTo.Type()
 	if fnv := t.getTranslator(tFrom, tTo); fnv.IsValid() {
-		vTo.Set(fnv.Call([]reflect.Value{vFrom})[0])
+		returns := fnv.Call([]reflect.Value{vFrom})
+		vTo.Set(returns[0])
+
+		// handle all the translations and "rebase" them to our current place
+		retSet := returns[1].Interface().(TranslationSet)
+		for _, trans := range retSet.Set {
+			from := fromPath.Append(trans.From.Path...)
+			to := toPath.Append(trans.To.Path...)
+			t.translations.AddTranslation(from, to)
+		}
 		return
 	}
 	if t.translatable(tFrom, tTo) {
-		t.translateSameType(vFrom, vTo)
+		t.translateSameType(vFrom, vTo, fromPath, toPath)
 		return
 	}
 
@@ -143,21 +185,105 @@ func (t translator) translate(vFrom, vTo reflect.Value) {
 }
 
 type Translator interface {
+	// Adds a custom translator for cases where the structs are not identical. Must be of type
+	// func(fromType) -> (toType, TranslationSet). The translator should return the set of all
+	// translations it did.
 	AddCustomTranslator(t interface{})
-	Translate(from, to interface{})
+	// Also returns a list of source and dest paths, autocompleted by fromTag and toTag
+	Translate(from, to interface{}) TranslationSet
 }
 
-func NewTranslator() Translator {
-	return &translator{}
+// Translation represents how a path changes when translating. If something at $yaml.storage.filesystems.4
+// generates content at $json.systemd.units.3 a translation can represent that. This allows validation errors
+// in Ignition structs to be tracked back to their source in the yaml.
+type Translation struct {
+	From path.ContextPath
+	To   path.ContextPath
+}
+
+// TranslationSet represents all of the translations that occurred. They're stored in a map from a string representation
+// of the destination path to the translation struct. The map is purely an optimization to allow fast lookups. Ideally the
+// map would just be from the destination path.ContextPath to the source path.ContextPath, but ContextPath contains a slice
+// which are not comparable and thus cannot be used as keys in maps.
+type TranslationSet struct {
+	FromTag string
+	ToTag   string
+	Set     map[string]Translation
+}
+
+// AddTranslation adds a translation to the set
+func (ts TranslationSet) AddTranslation(from, to path.ContextPath) {
+	translation := Translation{
+		From: from,
+		To:   to,
+	}
+	toString := translation.To.String()
+	ts.Set[toString] = translation
+}
+
+// Shortcut for AddTranslation for identity translations
+func (ts TranslationSet) AddIdentity(paths ...string) {
+	for _, p := range paths {
+		from := path.New(ts.FromTag, p)
+		to := path.New(ts.ToTag, p)
+		ts.AddTranslation(from, to)
+	}
+}
+
+// Merge adds all the entries to the set. It mutates the Set in place.
+func (ts TranslationSet) Merge(from TranslationSet) {
+	for _, t := range from.Set {
+		ts.Set[t.From.String()] = t
+	}
+}
+
+// MergeP is like Merge, but first it calls Prefix on the set being merged in.
+func (ts TranslationSet) MergeP(prefix interface{}, from TranslationSet) {
+	from = from.Prefix(prefix)
+	for _, t := range from.Set {
+		ts.Set[t.To.String()] = t
+	}
+}
+
+// Prefix returns a TranslationSet with all translation paths prefixed by prefix.
+func (ts TranslationSet) Prefix(prefix interface{}) TranslationSet {
+	ret := TranslationSet{
+		FromTag: ts.FromTag,
+		ToTag:   ts.ToTag,
+		Set:     map[string]Translation{},
+	}
+	p := []interface{}{prefix}
+	for _, tr := range ts.Set {
+		tr.From.Path = append(p, tr.From.Path...)
+		tr.To.Path = append(p, tr.To.Path...)
+		ret.AddTranslation(tr.From, tr.To)
+	}
+	return ret
+}
+
+// NewTranslator creates a new Translator for translating from types with fromTag struct tags (e.g. "yaml")
+// to types with toTag struct tages (e.g. "json"). These tags are used when determining paths when generating
+// the TranslationSet returned by Translator.Translate()
+func NewTranslator(fromTag, toTag string) Translator {
+	return &translator{
+		translations: TranslationSet{
+			FromTag: fromTag,
+			ToTag:   toTag,
+			Set:     map[string]Translation{},
+		},
+	}
 }
 
 type translator struct {
 	// List of custom translation funcs, must pass couldBeValidTranslator
 	// This is only for fields that cannot or should not be trivially translated,
 	// All trivially translated fields use the default behavior.
-	translators []reflect.Value
+	translators  []reflect.Value
+	translations TranslationSet
 }
 
+// fn should be of the form func(fromType, translationsMap) -> toType
+// fn should mutate translationsMap to add all the translations it did
 func (t *translator) AddCustomTranslator(fn interface{}) {
 	fnv := reflect.ValueOf(fn)
 	if !couldBeValidTranslator(fnv.Type()) {
@@ -175,7 +301,8 @@ func (t translator) getTranslator(from, to reflect.Type) reflect.Value {
 	return reflect.Value{}
 }
 
-func (t translator) Translate(from, to interface{}) {
+// Translate translates from into to and returns a set of all the path changes it performed.
+func (t translator) Translate(from, to interface{}) TranslationSet {
 	fv := reflect.ValueOf(from)
 	tv := reflect.ValueOf(to)
 	if fv.Kind() != reflect.Ptr || tv.Kind() != reflect.Ptr {
@@ -183,5 +310,12 @@ func (t translator) Translate(from, to interface{}) {
 	}
 	fv = fv.Elem()
 	tv = tv.Elem()
-	t.translate(fv, tv)
+	// Make sure to clear this every time`
+	t.translations = TranslationSet{
+		FromTag: t.translations.FromTag,
+		ToTag:   t.translations.ToTag,
+		Set:     map[string]Translation{},
+	}
+	t.translate(fv, tv, path.New(t.translations.FromTag), path.New(t.translations.ToTag))
+	return t.translations
 }

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -1,0 +1,205 @@
+// Copyright 2019 Red Hat, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package translate
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+
+	"github.com/coreos/ignition/v2/config/translate/tests/pkga"
+	"github.com/coreos/ignition/v2/config/translate/tests/pkgb"
+)
+
+// Note: we need different input and output types which unfortunately means a lot of tests
+
+func TestTranslateTrivial(t *testing.T) {
+	in := pkga.Trivial{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	expected := pkgb.Trivial{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	got := pkgb.Trivial{}
+
+	trans := NewTranslator()
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}
+
+func TestTranslateNested(t *testing.T) {
+	in := pkga.Nested{
+		D: "foobar",
+		Trivial: pkga.Trivial{
+			A: "asdf",
+			B: 5,
+			C: true,
+		},
+	}
+
+	expected := pkgb.Nested{
+		D: "foobar",
+		Trivial: pkgb.Trivial{
+			A: "asdf",
+			B: 5,
+			C: true,
+		},
+	}
+
+	got := pkgb.Nested{}
+
+	trans := NewTranslator()
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}
+
+func TestTranslateTrivialReordered(t *testing.T) {
+	in := pkga.TrivialReordered{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	expected := pkgb.TrivialReordered{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	got := pkgb.TrivialReordered{}
+
+	trans := NewTranslator()
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}
+
+func TestCustomTranslatorTrivial(t *testing.T) {
+	tr := func(a pkga.Trivial) pkgb.Nested {
+		return pkgb.Nested{
+			Trivial: pkgb.Trivial{
+				A: a.A,
+				B: a.B,
+				C: a.C,
+			},
+			D: "abc",
+		}
+	}
+	in := pkga.Trivial{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	expected := pkgb.Nested{
+		D: "abc",
+		Trivial: pkgb.Trivial{
+			A: "asdf",
+			B: 5,
+			C: true,
+		},
+	}
+
+	got := pkgb.Nested{}
+
+	trans := NewTranslator()
+	trans.AddCustomTranslator(tr)
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}
+
+func TestCustomTranslatorTrivialWithAutomaticResume(t *testing.T) {
+	trans := NewTranslator()
+	tr := func(a pkga.Trivial) pkgb.Nested {
+		ret := pkgb.Nested{
+			D: "abc",
+		}
+		trans.Translate(&a, &ret.Trivial)
+		return ret
+	}
+	in := pkga.Trivial{
+		A: "asdf",
+		B: 5,
+		C: true,
+	}
+
+	expected := pkgb.Nested{
+		D: "abc",
+		Trivial: pkgb.Trivial{
+			A: "asdf",
+			B: 5,
+			C: true,
+		},
+	}
+
+	got := pkgb.Nested{}
+
+	trans.AddCustomTranslator(tr)
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}
+
+func TestCustomTranslatorList(t *testing.T) {
+	tr := func(a pkga.Trivial) pkgb.Nested {
+		return pkgb.Nested{
+			Trivial: pkgb.Trivial{
+				A: a.A,
+				B: a.B,
+				C: a.C,
+			},
+			D: "abc",
+		}
+	}
+	in := pkga.HasList{
+		L: []pkga.Trivial{
+			{
+				A: "asdf",
+				B: 5,
+				C: true,
+			},
+		},
+	}
+
+	expected := pkgb.HasList{
+		L: []pkgb.Nested{
+			{
+				D: "abc",
+				Trivial: pkgb.Trivial{
+					A: "asdf",
+					B: 5,
+					C: true,
+				},
+			},
+		},
+	}
+
+	got := pkgb.HasList{}
+
+	trans := NewTranslator()
+	trans.AddCustomTranslator(tr)
+
+	trans.Translate(&in, &got)
+	assert.Equal(t, got, expected, "bad translation")
+}


### PR DESCRIPTION
In this PR:
 - Fork Ignition's translation code - we need to do more complex things than it ever did
 - Update the translation code to also emit a list of (src, dest) paths. For example you might have (`$yaml.storage.files.4.contents.inline`, `$json.storage.files.4.contents.source`) meaning the 5th element of the files in the generating config got it's source field from the corresponding inline field in the fcc. 
 - Use that list of translations to convert a report with ignition paths to fcc paths, then correlate that to the actual source for line/col information.
 - Add a bunch of helpers to make writing translators for that easier
 - Update tests for handle all this and test the new functionality