### PR TITLE
Add spec 1.1.0-experimental

### DIFF
--- a/base/v0_2_exp/schema.go
+++ b/base/v0_2_exp/schema.go
@@ -85,6 +85,7 @@ type Group string
 
 type Ignition struct {
 	Config   IgnitionConfig `yaml:"config"`
+	Proxy    Proxy          `yaml:"proxy"`
 	Security Security       `yaml:"security"`
 	Timeouts Timeouts       `yaml:"timeouts"`
 }
@@ -150,6 +151,12 @@ type PasswdUser struct {
 	Shell             *string            `yaml:"shell"`
 	System            *bool              `yaml:"system"`
 	UID               *int               `yaml:"uid"`
+}
+
+type Proxy struct {
+	HTTPProxy  *string  `yaml:"http_proxy"`
+	HTTPSProxy *string  `yaml:"https_proxy"`
+	NoProxy    []string `yaml:"no_proxy"`
 }
 
 type Raid struct {

--- a/base/v0_2_exp/schema.go
+++ b/base/v0_2_exp/schema.go
@@ -1,0 +1,203 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+type CaReference struct {
+	Source       string       `yaml:"source"`
+	Verification Verification `yaml:"verification"`
+}
+
+type Config struct {
+	Ignition Ignition `yaml:"ignition"`
+	Passwd   Passwd   `yaml:"passwd"`
+	Storage  Storage  `yaml:"storage"`
+	Systemd  Systemd  `yaml:"systemd"`
+}
+
+type ConfigReference struct {
+	Source       *string      `yaml:"source"`
+	Verification Verification `yaml:"verification"`
+}
+
+type Device string
+
+type Directory struct {
+	Group     NodeGroup `yaml:"group"`
+	Overwrite *bool     `yaml:"overwrite"`
+	Path      string    `yaml:"path"`
+	User      NodeUser  `yaml:"user"`
+	Mode      *int      `yaml:"mode"`
+}
+
+type Disk struct {
+	Device     string      `yaml:"device"`
+	Partitions []Partition `yaml:"partitions"`
+	WipeTable  *bool       `yaml:"wipe_table"`
+}
+
+type Dropin struct {
+	Contents *string `yaml:"contents"`
+	Name     string  `yaml:"name"`
+}
+
+type File struct {
+	Group     NodeGroup      `yaml:"group"`
+	Overwrite *bool          `yaml:"overwrite"`
+	Path      string         `yaml:"path"`
+	User      NodeUser       `yaml:"user"`
+	Append    []FileContents `yaml:"append"`
+	Contents  FileContents   `yaml:"contents"`
+	Mode      *int           `yaml:"mode"`
+}
+
+type FileContents struct {
+	Compression  *string      `yaml:"compression"`
+	Source       *string      `yaml:"source"`
+	Inline       *string      `yaml:"inline"` // Added, not in ignition spec
+	Verification Verification `yaml:"verification"`
+}
+
+type Filesystem struct {
+	Device         string             `yaml:"device"`
+	Format         *string            `yaml:"format"`
+	Label          *string            `yaml:"label"`
+	Options        []FilesystemOption `yaml:"options"`
+	Path           *string            `yaml:"path"`
+	UUID           *string            `yaml:"uuid"`
+	WipeFilesystem *bool              `yaml:"wipe_filesystem"`
+}
+
+type FilesystemOption string
+
+type Group string
+
+type Ignition struct {
+	Config   IgnitionConfig `yaml:"config"`
+	Security Security       `yaml:"security"`
+	Timeouts Timeouts       `yaml:"timeouts"`
+}
+
+type IgnitionConfig struct {
+	Merge   []ConfigReference `yaml:"merge"`
+	Replace ConfigReference   `yaml:"replace"`
+}
+
+type Link struct {
+	Group     NodeGroup `yaml:"group"`
+	Overwrite *bool     `yaml:"overwrite"`
+	Path      string    `yaml:"path"`
+	User      NodeUser  `yaml:"user"`
+	Hard      *bool     `yaml:"hard"`
+	Target    string    `yaml:"target"`
+}
+
+type NodeGroup struct {
+	ID   *int    `yaml:"id"`
+	Name *string `yaml:"name"`
+}
+
+type NodeUser struct {
+	ID   *int    `yaml:"id"`
+	Name *string `yaml:"name"`
+}
+
+type Partition struct {
+	GUID               *string `yaml:"guid"`
+	Label              *string `yaml:"label"`
+	Number             int     `yaml:"number"`
+	ShouldExist        *bool   `yaml:"should_exist"`
+	SizeMiB            *int    `yaml:"size_mib"`
+	StartMiB           *int    `yaml:"start_mib"`
+	TypeGUID           *string `yaml:"type_guid"`
+	WipePartitionEntry *bool   `yaml:"wipe_partition_entry"`
+}
+
+type Passwd struct {
+	Groups []PasswdGroup `yaml:"groups"`
+	Users  []PasswdUser  `yaml:"users"`
+}
+
+type PasswdGroup struct {
+	Gid          *int    `yaml:"gid"`
+	Name         string  `yaml:"name"`
+	PasswordHash *string `yaml:"password_hash"`
+	System       *bool   `yaml:"system"`
+}
+
+type PasswdUser struct {
+	Gecos             *string            `yaml:"gecos"`
+	Groups            []Group            `yaml:"groups"`
+	HomeDir           *string            `yaml:"home_dir"`
+	Name              string             `yaml:"name"`
+	NoCreateHome      *bool              `yaml:"no_create_home"`
+	NoLogInit         *bool              `yaml:"no_log_init"`
+	NoUserGroup       *bool              `yaml:"no_user_group"`
+	PasswordHash      *string            `yaml:"password_hash"`
+	PrimaryGroup      *string            `yaml:"primary_group"`
+	SSHAuthorizedKeys []SSHAuthorizedKey `yaml:"ssh_authorized_keys"`
+	Shell             *string            `yaml:"shell"`
+	System            *bool              `yaml:"system"`
+	UID               *int               `yaml:"uid"`
+}
+
+type Raid struct {
+	Devices []Device     `yaml:"devices"`
+	Level   string       `yaml:"level"`
+	Name    string       `yaml:"name"`
+	Options []RaidOption `yaml:"options"`
+	Spares  *int         `yaml:"spares"`
+}
+
+type RaidOption string
+
+type SSHAuthorizedKey string
+
+type Security struct {
+	TLS TLS `yaml:"tls"`
+}
+
+type Storage struct {
+	Directories []Directory  `yaml:"directories"`
+	Disks       []Disk       `yaml:"disks"`
+	Files       []File       `yaml:"files"`
+	Filesystems []Filesystem `yaml:"filesystems"`
+	Links       []Link       `yaml:"links"`
+	Raid        []Raid       `yaml:"raid"`
+}
+
+type Systemd struct {
+	Units []Unit `yaml:"units"`
+}
+
+type TLS struct {
+	CertificateAuthorities []CaReference `yaml:"certificate_authorities"`
+}
+
+type Timeouts struct {
+	HTTPResponseHeaders *int `yaml:"http_response_headers"`
+	HTTPTotal           *int `yaml:"http_total"`
+}
+
+type Unit struct {
+	Contents *string  `yaml:"contents"`
+	Dropins  []Dropin `yaml:"dropins"`
+	Enabled  *bool    `yaml:"enabled"`
+	Mask     *bool    `yaml:"mask"`
+	Name     string   `yaml:"name"`
+}
+
+type Verification struct {
+	Hash *string `yaml:"hash"`
+}

--- a/base/v0_2_exp/translate.go
+++ b/base/v0_2_exp/translate.go
@@ -1,0 +1,101 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	"net/url"
+
+	"github.com/coreos/fcct/translate"
+
+	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/vincent-petithory/dataurl"
+)
+
+// ToIgn3_0 translates the config to an Ignition config. It also returns the set of translations
+// it did so paths in the resultant config can be tracked back to their source in the source config.
+func (c Config) ToIgn3_0() (types.Config, translate.TranslationSet, error) {
+	ret := types.Config{}
+	tr := translate.NewTranslator("yaml", "json")
+	tr.AddCustomTranslator(translateIgnition)
+	tr.AddCustomTranslator(translateFile)
+	tr.AddCustomTranslator(translateDirectory)
+	tr.AddCustomTranslator(translateLink)
+	translations := tr.Translate(&c, &ret)
+	return ret, translations, nil
+}
+
+func translateIgnition(from Ignition) (to types.Ignition, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	to.Version = types.MaxVersion.String()
+	tm = tr.Translate(&from.Config, &to.Config).Prefix("config")
+	tm.MergeP("security", tr.Translate(&from.Security, &to.Security))
+	tm.MergeP("timeouts", tr.Translate(&from.Timeouts, &to.Timeouts))
+	return
+}
+
+func translateFile(from File) (to types.File, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tr.AddCustomTranslator(translateFileContents)
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
+	tm.MergeP("append", tr.Translate(&from.Append, &to.Append))
+	tm.MergeP("contents", tr.Translate(&from.Contents, &to.Contents))
+	to.Overwrite = from.Overwrite
+	to.Path = from.Path
+	to.Mode = from.Mode
+	tm.AddIdentity("overwrite", "path", "mode")
+	return
+}
+
+func translateFileContents(from FileContents) (to types.FileContents, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Verification, &to.Verification).Prefix("verification")
+	to.Source = from.Source
+	to.Compression = from.Compression
+	tm.AddIdentity("source", "compression")
+	if from.Inline != nil {
+		src := (&url.URL{
+			Scheme: "data",
+			Opaque: "," + dataurl.EscapeString(*from.Inline),
+		}).String()
+		to.Source = &src
+		tm.AddTranslation(path.New("yaml", "inline"), path.New("json", "source"))
+	}
+	return
+}
+
+func translateDirectory(from Directory) (to types.Directory, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
+	to.Overwrite = from.Overwrite
+	to.Path = from.Path
+	to.Mode = from.Mode
+	tm.AddIdentity("overwrite", "path", "mode")
+	return
+}
+
+func translateLink(from Link) (to types.Link, tm translate.TranslationSet) {
+	tr := translate.NewTranslator("yaml", "json")
+	tm = tr.Translate(&from.Group, &to.Group).Prefix("group")
+	tm.MergeP("user", tr.Translate(&from.User, &to.User))
+	to.Target = from.Target
+	to.Hard = from.Hard
+	to.Overwrite = from.Overwrite
+	to.Path = from.Path
+	tm.AddIdentity("target", "hard", "overwrite", "path")
+	return
+}

--- a/base/v0_2_exp/translate.go
+++ b/base/v0_2_exp/translate.go
@@ -41,6 +41,7 @@ func translateIgnition(from Ignition) (to types.Ignition, tm translate.Translati
 	tr := translate.NewTranslator("yaml", "json")
 	to.Version = types.MaxVersion.String()
 	tm = tr.Translate(&from.Config, &to.Config).Prefix("config")
+	tm.MergeP("proxy", tr.Translate(&from.Proxy, &to.Proxy))
 	tm.MergeP("security", tr.Translate(&from.Security, &to.Security))
 	tm.MergeP("timeouts", tr.Translate(&from.Timeouts, &to.Timeouts))
 	return

--- a/base/v0_2_exp/translate.go
+++ b/base/v0_2_exp/translate.go
@@ -19,14 +19,14 @@ import (
 
 	"github.com/coreos/fcct/translate"
 
-	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/vincent-petithory/dataurl"
 )
 
 // ToIgn3_0 translates the config to an Ignition config. It also returns the set of translations
 // it did so paths in the resultant config can be tracked back to their source in the source config.
-func (c Config) ToIgn3_0() (types.Config, translate.TranslationSet, error) {
+func (c Config) ToIgn3_1() (types.Config, translate.TranslationSet, error) {
 	ret := types.Config{}
 	tr := translate.NewTranslator("yaml", "json")
 	tr.AddCustomTranslator(translateIgnition)

--- a/base/v0_2_exp/translate_test.go
+++ b/base/v0_2_exp/translate_test.go
@@ -286,6 +286,21 @@ func TestTranslateIgnition(t *testing.T) {
 				Version: "3.1.0-experimental",
 			},
 		},
+		{
+			Ignition{
+				Proxy: Proxy{
+					HTTPProxy: util.StrToPtr("https://example.com:8080"),
+					NoProxy:   []string{"example.com"},
+				},
+			},
+			types.Ignition{
+				Version: "3.1.0-experimental",
+				Proxy: types.Proxy{
+					HTTPProxy: util.StrToPtr("https://example.com:8080"),
+					NoProxy:   []types.NoProxyItem{types.NoProxyItem("example.com")},
+				},
+			},
+		},
 	}
 	for i, test := range tests {
 		actual, _ := translateIgnition(test.in)

--- a/base/v0_2_exp/translate_test.go
+++ b/base/v0_2_exp/translate_test.go
@@ -1,0 +1,324 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/fcct/translate"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/vcontext/path"
+)
+
+// Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+// verifyTranslations ensures all the translations are identity, unless they match a listed one
+// it returns the offending translation if there is one
+func verifyTranslations(set translate.TranslationSet, exceptions ...translate.Translation) *translate.Translation {
+	exceptionSet := translate.TranslationSet{
+		FromTag: set.FromTag,
+		ToTag:   set.ToTag,
+		Set:     map[string]translate.Translation{},
+	}
+	for _, ex := range exceptions {
+		exceptionSet.AddTranslation(ex.From, ex.To)
+	}
+	for key, translation := range set.Set {
+		if ex, ok := exceptionSet.Set[key]; ok {
+			if !reflect.DeepEqual(translation, ex) {
+				return &ex
+			}
+		} else if !reflect.DeepEqual(translation.From.Path, translation.To.Path) {
+			return &translation
+		}
+	}
+	return nil
+}
+
+// TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entires.
+func TestTranslateFile(t *testing.T) {
+	tests := []struct {
+		in         File
+		out        types.File
+		exceptions []translate.Translation
+	}{
+		{
+			File{},
+			types.File{},
+			nil,
+		},
+		{
+			// contains invalid (by the validator's definition) combinations of fields,
+			// but the translator doesn't care and we can check they all get translated at once
+			File{
+				Path: "/foo",
+				Group: NodeGroup{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("foobar"),
+				},
+				User: NodeUser{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("bazquux"),
+				},
+				Mode: util.IntToPtr(420),
+				Append: []FileContents{
+					{
+						Source:      util.StrToPtr("http://example/com"),
+						Compression: util.StrToPtr("gzip"),
+						Verification: Verification{
+							Hash: util.StrToPtr("this isn't validated"),
+						},
+					},
+					{
+						Inline:      util.StrToPtr("hello"),
+						Compression: util.StrToPtr("gzip"),
+						Verification: Verification{
+							Hash: util.StrToPtr("this isn't validated"),
+						},
+					},
+				},
+				Overwrite: util.BoolToPtr(true),
+				Contents: FileContents{
+					Source:      util.StrToPtr("http://example/com"),
+					Compression: util.StrToPtr("gzip"),
+					Verification: Verification{
+						Hash: util.StrToPtr("this isn't validated"),
+					},
+				},
+			},
+			types.File{
+				Node: types.Node{
+					Path: "/foo",
+					Group: types.NodeGroup{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("foobar"),
+					},
+					User: types.NodeUser{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("bazquux"),
+					},
+					Overwrite: util.BoolToPtr(true),
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					Mode: util.IntToPtr(420),
+					Append: []types.FileContents{
+						{
+							Source:      util.StrToPtr("http://example/com"),
+							Compression: util.StrToPtr("gzip"),
+							Verification: types.Verification{
+								Hash: util.StrToPtr("this isn't validated"),
+							},
+						},
+						{
+							Source:      util.StrToPtr("data:,hello"),
+							Compression: util.StrToPtr("gzip"),
+							Verification: types.Verification{
+								Hash: util.StrToPtr("this isn't validated"),
+							},
+						},
+					},
+					Contents: types.FileContents{
+						Source:      util.StrToPtr("http://example/com"),
+						Compression: util.StrToPtr("gzip"),
+						Verification: types.Verification{
+							Hash: util.StrToPtr("this isn't validated"),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{
+					From: path.New("yaml", "append", 1, "inline"),
+					To:   path.New("json", "append", 1, "source"),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		actual, translations := translateFile(test.in)
+
+		if !reflect.DeepEqual(actual, test.out) {
+			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		}
+
+		if errT := verifyTranslations(translations, test.exceptions...); errT != nil {
+			t.Errorf("#%d: bad translation: %v", i, *errT)
+		}
+	}
+}
+
+// TestTranslateDirectory tests translating the ct storage.directories.[i] entries to ignition storage.directories.[i] entires.
+func TestTranslateDirectory(t *testing.T) {
+	tests := []struct {
+		in  Directory
+		out types.Directory
+	}{
+		{
+			Directory{},
+			types.Directory{},
+		},
+		{
+			// contains invalid (by the validator's definition) combinations of fields,
+			// but the translator doesn't care and we can check they all get translated at once
+			Directory{
+				Path: "/foo",
+				Group: NodeGroup{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("foobar"),
+				},
+				User: NodeUser{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("bazquux"),
+				},
+				Mode:      util.IntToPtr(420),
+				Overwrite: util.BoolToPtr(true),
+			},
+			types.Directory{
+				Node: types.Node{
+					Path: "/foo",
+					Group: types.NodeGroup{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("foobar"),
+					},
+					User: types.NodeUser{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("bazquux"),
+					},
+					Overwrite: util.BoolToPtr(true),
+				},
+				DirectoryEmbedded1: types.DirectoryEmbedded1{
+					Mode: util.IntToPtr(420),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		actual, _ := translateDirectory(test.in)
+		if !reflect.DeepEqual(actual, test.out) {
+			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		}
+	}
+}
+
+// TestTranslateLink tests translating the ct storage.links.[i] entries to ignition storage.links.[i] entires.
+func TestTranslateLink(t *testing.T) {
+	tests := []struct {
+		in  Link
+		out types.Link
+	}{
+		{
+			Link{},
+			types.Link{},
+		},
+		{
+			// contains invalid (by the validator's definition) combinations of fields,
+			// but the translator doesn't care and we can check they all get translated at once
+			Link{
+				Path: "/foo",
+				Group: NodeGroup{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("foobar"),
+				},
+				User: NodeUser{
+					ID:   util.IntToPtr(1),
+					Name: util.StrToPtr("bazquux"),
+				},
+				Overwrite: util.BoolToPtr(true),
+				Target:    "/bar",
+				Hard:      util.BoolToPtr(false),
+			},
+			types.Link{
+				Node: types.Node{
+					Path: "/foo",
+					Group: types.NodeGroup{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("foobar"),
+					},
+					User: types.NodeUser{
+						ID:   util.IntToPtr(1),
+						Name: util.StrToPtr("bazquux"),
+					},
+					Overwrite: util.BoolToPtr(true),
+				},
+				LinkEmbedded1: types.LinkEmbedded1{
+					Target: "/bar",
+					Hard:   util.BoolToPtr(false),
+				},
+			},
+		},
+	}
+
+	for i, test := range tests {
+		actual, _ := translateLink(test.in)
+		if !reflect.DeepEqual(actual, test.out) {
+			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		}
+	}
+}
+
+// TestTranslateIgnition tests translating the ct config.ignition to the ignition config.ignition section.
+// It ensure that the version is set as well.
+func TestTranslateIgnition(t *testing.T) {
+	tests := []struct {
+		in  Ignition
+		out types.Ignition
+	}{
+		{
+			Ignition{},
+			types.Ignition{
+				Version: "3.0.0",
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, _ := translateIgnition(test.in)
+		if !reflect.DeepEqual(actual, test.out) {
+			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		}
+	}
+}
+
+// TestToIgn3_0 tests the config.ToIgn3_0 function ensuring it will generate a valid config even when empty. Not much else is
+// tested since it uses the Ignition translation code which has it's own set of tests.
+func TestToIgn3_0(t *testing.T) {
+	tests := []struct {
+		in  Config
+		out types.Config
+	}{
+		{
+			Config{},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.0.0",
+				},
+			},
+		},
+	}
+	for i, test := range tests {
+		actual, _, err := test.in.ToIgn3_0()
+		if err != nil {
+			t.Errorf("#%d: got error: %v", i, err)
+		}
+
+		if !reflect.DeepEqual(actual, test.out) {
+			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
+		}
+	}
+}

--- a/base/v0_2_exp/translate_test.go
+++ b/base/v0_2_exp/translate_test.go
@@ -21,7 +21,7 @@ import (
 	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/ignition/v2/config/v3_0/types"
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
 	"github.com/coreos/vcontext/path"
 )
 
@@ -283,7 +283,7 @@ func TestTranslateIgnition(t *testing.T) {
 		{
 			Ignition{},
 			types.Ignition{
-				Version: "3.0.0",
+				Version: "3.1.0-experimental",
 			},
 		},
 	}
@@ -295,9 +295,9 @@ func TestTranslateIgnition(t *testing.T) {
 	}
 }
 
-// TestToIgn3_0 tests the config.ToIgn3_0 function ensuring it will generate a valid config even when empty. Not much else is
+// TestToIgn3_1 tests the config.ToIgn3_1 function ensuring it will generate a valid config even when empty. Not much else is
 // tested since it uses the Ignition translation code which has it's own set of tests.
-func TestToIgn3_0(t *testing.T) {
+func TestToIgn3_1(t *testing.T) {
 	tests := []struct {
 		in  Config
 		out types.Config
@@ -306,13 +306,13 @@ func TestToIgn3_0(t *testing.T) {
 			Config{},
 			types.Config{
 				Ignition: types.Ignition{
-					Version: "3.0.0",
+					Version: "3.1.0-experimental",
 				},
 			},
 		},
 	}
 	for i, test := range tests {
-		actual, _, err := test.in.ToIgn3_0()
+		actual, _, err := test.in.ToIgn3_1()
 		if err != nil {
 			t.Errorf("#%d: got error: %v", i, err)
 		}

--- a/base/v0_2_exp/validate.go
+++ b/base/v0_2_exp/validate.go
@@ -1,0 +1,33 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	"errors"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+var (
+	ErrInlineAndSource = errors.New("inline cannot be specified if source is specified")
+)
+
+func (f FileContents) Validate(c path.ContextPath) (r report.Report) {
+	if f.Inline != nil && f.Source != nil {
+		r.AddOnError(c.Append("inline"), ErrInlineAndSource)
+	}
+	return
+}

--- a/base/v0_2_exp/validate_test.go
+++ b/base/v0_2_exp/validate_test.go
@@ -1,0 +1,79 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+)
+
+// TestValidateFileContents tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
+func TestValidateFileContents(t *testing.T) {
+	tests := []struct {
+		in  FileContents
+		out error
+	}{
+		{},
+		{
+			// contains invalid (by the validator's definition) combinations of fields,
+			// but the translator doesn't care and we can check they all get translated at once
+			FileContents{
+				Source:      util.StrToPtr("http://example/com"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			nil,
+		},
+		{
+			FileContents{
+				Inline:      util.StrToPtr("hello"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			nil,
+		},
+		{
+			FileContents{
+				Source:      util.StrToPtr("data:,hello"),
+				Inline:      util.StrToPtr("hello"),
+				Compression: util.StrToPtr("gzip"),
+				Verification: Verification{
+					Hash: util.StrToPtr("this isn't validated"),
+				},
+			},
+			ErrInlineAndSource,
+		},
+	}
+
+	for i, test := range tests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		// hardcode inline for now since that's the only place errors occur. Move into the
+		// test struct once there's more than one place
+		expected.AddOnError(path.New("yaml", "inline"), test.out)
+
+		if !reflect.DeepEqual(actual, expected) {
+			t.Errorf("#%d: expected %+v got %+v", i, expected, actual)
+		}
+	}
+}

--- a/config/config.go
+++ b/config/config.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/config/v1_0"
+	"github.com/coreos/fcct/config/v1_1_exp"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/vcontext/report"
@@ -31,7 +32,8 @@ var (
 	ErrInvalidVersion = errors.New("Error parsing version. Version must be a valid semver")
 
 	registry = map[string]translator{
-		"fcos+1.0.0": v1_0.TranslateBytes,
+		"fcos+1.0.0":              v1_0.TranslateBytes,
+		"fcos+1.1.0-experimental": v1_1_exp.TranslateBytes,
 	}
 )
 

--- a/config/v1_1_exp/fcos.go
+++ b/config/v1_1_exp/fcos.go
@@ -1,0 +1,96 @@
+// Copyright 2019 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_1_exp
+
+import (
+	"errors"
+	"reflect"
+
+	base_0_2 "github.com/coreos/fcct/base/v0_2_exp"
+	"github.com/coreos/fcct/config/common"
+	fcos_0_1 "github.com/coreos/fcct/distro/fcos/v0_1"
+	"github.com/coreos/fcct/translate"
+
+	"github.com/coreos/ignition/v2/config/v3_1_experimental/types"
+	ignvalidate "github.com/coreos/ignition/v2/config/validate"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/coreos/vcontext/validate"
+)
+
+var (
+	ErrInvalidConfig = errors.New("config generated was invalid")
+)
+
+type Config struct {
+	common.Common   `yaml:",inline"`
+	base_0_2.Config `yaml:",inline"`
+	fcos_0_1.Fcos   `yaml:",inline"`
+}
+
+func (c Config) Translate() (types.Config, translate.TranslationSet, error) {
+	cfg, baseTranslations, err := c.Config.ToIgn3_1()
+	if err != nil {
+		return types.Config{}, translate.TranslationSet{}, err
+	}
+
+	finalcfg, distroTranslations, err := c.Fcos.ToIgn3_1(cfg)
+	if err != nil {
+		return types.Config{}, translate.TranslationSet{}, err
+	}
+
+	baseTranslations.Merge(distroTranslations)
+
+	return finalcfg, baseTranslations, nil
+}
+
+// TranslateBytes translates from a v1.0 fcc to a v3.0.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, report.Report, error) {
+	cfg := Config{}
+
+	contextTree, err := common.Unmarshal(input, &cfg, options.Strict)
+	if err != nil {
+		return nil, report.Report{}, err
+	}
+
+	r := validate.Validate(cfg, "yaml")
+	unusedKeyCheck := func(v reflect.Value, c path.ContextPath) report.Report {
+		return ignvalidate.ValidateUnusedKeys(v, c, contextTree)
+	}
+	r.Merge(validate.ValidateCustom(cfg, "yaml", unusedKeyCheck))
+	r.Correlate(contextTree)
+	if r.IsFatal() {
+		return nil, r, ErrInvalidConfig
+	}
+
+	final, translations, err := cfg.Translate()
+	if err != nil {
+		return nil, r, err
+	}
+
+	second := validate.Validate(final, "json")
+	common.TranslateReportPaths(&second, translations)
+	second.Correlate(contextTree)
+	r.Merge(second)
+
+	if r.IsFatal() {
+		return nil, r, ErrInvalidConfig
+	}
+
+	outbytes, err := common.Marshal(final, options.Pretty)
+	return outbytes, r, err
+}

--- a/distro/fcos/v0_1/translate.go
+++ b/distro/fcos/v0_1/translate.go
@@ -17,10 +17,15 @@ package fcos_0_1
 import (
 	"github.com/coreos/fcct/translate"
 
-	"github.com/coreos/ignition/v2/config/v3_0/types"
+	types3_0 "github.com/coreos/ignition/v2/config/v3_0/types"
+	types3_1 "github.com/coreos/ignition/v2/config/v3_1_experimental/types"
 )
 
 // ToIgn3_0 takes a config and merges in the distro specific bits.
-func (f Fcos) ToIgn3_0(in types.Config) (types.Config, translate.TranslationSet, error) {
+func (f Fcos) ToIgn3_0(in types3_0.Config) (types3_0.Config, translate.TranslationSet, error) {
+	return in, translate.TranslationSet{}, nil
+}
+
+func (f Fcos) ToIgn3_1(in types3_1.Config) (types3_1.Config, translate.TranslationSet, error) {
 	return in, translate.TranslationSet{}, nil
 }

--- a/docs/configuration-v1_1-exp.md
+++ b/docs/configuration-v1_1-exp.md
@@ -25,6 +25,10 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
         * **source** (string): the URL of the certificate (in PEM format). Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
         * **_verification_** (object): options related to the verification of the certificate.
           * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is sha512.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_httpProxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `httpsProxy` or `noProxy`.
+    * **_httpsProxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `noProxy`.
+    * **_noProxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
 * **_storage_** (object): describes the desired state of the system's storage devices.
   * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
     * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.

--- a/docs/configuration-v1_1-exp.md
+++ b/docs/configuration-v1_1-exp.md
@@ -1,0 +1,128 @@
+# Configuration Specification v1.1.0-experimental #
+
+**Note: This configuration is experimental and has not been stablized. It is subject to change without warning or announcement**
+
+The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.0.0` and generates Ignition configs with version `3.0.0`.
+* **ignition** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+    * **_replace_** (object): the config that will replace the current.
+      * **source** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`.
+        * **source** (string): the URL of the certificate (in PEM format). Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is sha512.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
+      * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
+      * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
+      * **_wipe_partition_entry_** (boolean) if true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead.
+      * **_should_exist_** (boolean) whether or not the partition with the specified `number` should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on `wipePartitionEntry`. If false `number` must be specified and non-zero and `label`, `start`, `size`, `guid`, and `typeGuid` must all be omitted.
+  * **_raid_** (list of objects): the list of RAID arrays to be configured. Every RAID array must have a unique `name`.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. `path`, `device`, and `format` all need to be specified. Every filesystem must have a unique `device`.
+    * **path** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
+    * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](operator-notes.md#filesystem-reuse-semantics) for more information.
+    * **_label_** (string): the label of the filesystem.
+    * **_uuid_** (string): the uuid of the filesystem.
+    * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `source` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source`.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is `sha512`.
+    * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `source` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the symbolic link's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service"). Every unit must have a unique `name`.
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397


### PR DESCRIPTION
Add the experimental spec where development can take place. The v1.0 spec is frozen.
* [x] Add v1.1.0-experimental as a copy of v1.0
* [x] Add the new fields from Ignition v3.1.0-experiemtnal into `base/v0_2_exp`
* [x] Add tests
* [x] Add docs

Fixes https://github.com/coreos/fcct/issues/51