### PR TITLE
{docs,release-checklist}: add Quay tag pointing to latest release

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -4,7 +4,7 @@ Release checklist:
  - [ ] Ensure your local copy is up to date with master and your working directory is clean
  - [ ] Ensure you can sign commits and any yubikeys/smartcards are plugged in
  - [ ] Run `./tag_release.sh <vX.Y.z> <git commit hash>`
- - [ ] Push that tag to Github
+ - [ ] Push that tag to GitHub
  - [ ] Run `./build_releases`
  - [ ] Sign the release artifacts by running
 ```
@@ -12,5 +12,5 @@ gpg --local-user 0xCDDE268EBB729EC7! --detach-sign --armor <path to artifact>
 ```
 for each release artifact. Do not try to sign all of them at once by globbing. If you do, gpg will sign the combination of all the release artifacts instead of each one individually.
 
- - [ ] Create a draft release on Github and upload all the release artifacts and their signatures. Copy and paste the release notes from NEWS here as well.
+ - [ ] Create a draft release on GitHub and upload all the release artifacts and their signatures. Copy and paste the release notes from NEWS here as well.
  - [ ] Publish the release

--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -14,3 +14,6 @@ for each release artifact. Do not try to sign all of them at once by globbing. I
 
  - [ ] Create a draft release on GitHub and upload all the release artifacts and their signatures. Copy and paste the release notes from NEWS here as well.
  - [ ] Publish the release
+ - Update the `release` tag on Quay:
+   - [ ] Visit the [Quay tags page](https://quay.io/repository/coreos/fcct?tab=tags) and wait for a versioned tag to appear
+   - [ ] Click the gear next to the tag, select "Add New Tag", enter `release`, and confirm

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -21,17 +21,17 @@ New releases of `fcct` are backwards compatible with old releases unless otherwi
 
 #### Container
 
-This example uses podman, but docker can also be used. Substitute v0.2.0 with the desired version. Note that the `latest` tag corresponds with `master` and not with the latest release.
+This example uses podman, but docker can also be used.
 
 ```bash
 # Pull the desired version
-podman pull quay.io/coreos/fcct:v0.2.0
+podman pull quay.io/coreos/fcct:release
 
 # Run fcct using standard in and standard out
-podman run -i --rm quay.io/coreos/fcct:v0.2.0 -pretty -strict < your_config.fcc > transpiled_config.ign
+podman run -i --rm quay.io/coreos/fcct:release -pretty -strict < your_config.fcc > transpiled_config.ign
 
 # Run fcct using files.
-podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:v0.2.0 -pretty -strict -input /config.fcc > transpiled_config.ign
+podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release -pretty -strict -input /config.fcc > transpiled_config.ign
 ```
 
 ### Writing and using Fedora CoreOS Configs


### PR DESCRIPTION
Don't expect users to know the version number of the current release.

Fixes #63.