### PR TITLE
main: accept input filename as bare argument; deprecate --input

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -31,7 +31,7 @@ podman pull quay.io/coreos/fcct:release
 podman run -i --rm quay.io/coreos/fcct:release --pretty --strict < your_config.fcc > transpiled_config.ign
 
 # Run fcct using files.
-podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict --input /config.fcc > transpiled_config.ign
+podman run --rm -v /path/to/your_config.fcc:/config.fcc:z quay.io/coreos/fcct:release --pretty --strict /config.fcc > transpiled_config.ign
 ```
 
 ### Writing and using Fedora CoreOS Configs
@@ -53,7 +53,7 @@ In this above file, you'll want to set the `ssh-rsa AAAAB3NzaC1yc...` line to be
 If we take this file and give it to `fcct`:
 
 ```
-$ ./bin/amd64/fcct --input example.yaml
+$ ./bin/amd64/fcct example.yaml
 
 {"ignition":{"config":{"replace":{"source":null,"verification":{}}},"security":{"tls":{}},"timeouts":{},"version":"3.0.0"},"passwd":{"users":[{"name":"core","sshAuthorizedKeys":["ssh-rsa ssh-rsa AAAAB3NzaC1yc..."]}]},"storage":{},"systemd":{}}
 ```

--- a/internal/main.go
+++ b/internal/main.go
@@ -44,9 +44,24 @@ func main() {
 	pflag.BoolVarP(&options.Strict, "strict", "s", false, "fail on any warning")
 	pflag.BoolVarP(&options.Pretty, "pretty", "p", false, "output formatted json")
 	pflag.StringVar(&input, "input", "", "read from input file instead of stdin")
+	pflag.Lookup("input").Deprecated = "specify filename directly on command line"
+	pflag.Lookup("input").Hidden = true
 	pflag.StringVarP(&output, "output", "o", "", "write to output file instead of stdout")
 
+	pflag.Usage = func() {
+		fmt.Fprintf(os.Stderr, "Usage: %s [options] [input-file]\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "Options:\n")
+		pflag.PrintDefaults()
+	}
 	pflag.Parse()
+
+	args := pflag.Args()
+	if len(args) == 1 && input == "" {
+		input = args[0]
+	} else if len(args) > 0 {
+		pflag.Usage()
+		os.Exit(2)
+	}
 
 	if helpFlag {
 		pflag.Usage()


### PR DESCRIPTION
Accept input filename as bare argument rather than requiring the `--input` option.  Continue accepting `--input` but hide it from `--help`.

Also, fail if we receive extra command-line arguments.

Fixes #69.  Depends on #70.