### PR TITLE
distro: add rhcos

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -33,9 +33,12 @@ var (
 	ErrInvalidVersion = errors.New("Error parsing version. Version must be a valid semver")
 
 	registry = map[string]translator{
-		"fcos+1.0.0":              v1_0.TranslateBytes,
-		"fcos+1.1.0":              v1_1.TranslateBytes,
-		"fcos+1.2.0-experimental": v1_2_exp.TranslateBytes,
+		"fcos+1.0.0":               v1_0.TranslateBytes,
+		"fcos+1.1.0":               v1_1.TranslateBytes,
+		"fcos+1.2.0-experimental":  v1_2_exp.TranslateBytes,
+		"rhcos+1.0.0":              v1_0.TranslateBytes,
+		"rhcos+1.1.0":              v1_1.TranslateBytes,
+		"rhcos+1.2.0-experimental": v1_2_exp.TranslateBytes,
 	}
 )
 

--- a/distro/rhcos/v0_1/schema.go
+++ b/distro/rhcos/v0_1/schema.go
@@ -1,0 +1,18 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package rhcos_0_1
+
+type Rhcos struct {
+}

--- a/distro/rhcos/v0_1/translate.go
+++ b/distro/rhcos/v0_1/translate.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package rhcos_0_1
+
+import (
+	"github.com/coreos/fcct/base"
+	"github.com/coreos/fcct/translate"
+
+	types3_0 "github.com/coreos/ignition/v2/config/v3_0/types"
+	types3_1 "github.com/coreos/ignition/v2/config/v3_1/types"
+	types3_2 "github.com/coreos/ignition/v2/config/v3_2_experimental/types"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_0 takes a config and merges in the distro specific bits.
+func (r Rhcos) ToIgn3_0(in types3_0.Config, options base.TranslateOptions) (types3_0.Config, translate.TranslationSet, report.Report) {
+	return in, translate.TranslationSet{}, report.Report{}
+}
+
+func (r Rhcos) ToIgn3_1(in types3_1.Config, options base.TranslateOptions) (types3_1.Config, translate.TranslationSet, report.Report) {
+	return in, translate.TranslationSet{}, report.Report{}
+}
+
+func (r Rhcos) ToIgn3_2(in types3_2.Config, options base.TranslateOptions) (types3_2.Config, translate.TranslationSet, report.Report) {
+	return in, translate.TranslationSet{}, report.Report{}
+}


### PR DESCRIPTION
This adds an RHCOS variant. It is currently a no-op and just allows the
usage of the variant name in the configuration.

NOTE: Current versions of RHCOS are still based on Ignition spec 2.x
configs and will not be able to use the configs output by FCCT.