### PR TITLE
main: append newline to output

### DIFF
--- a/internal/main.go
+++ b/internal/main.go
@@ -104,7 +104,7 @@ func main() {
 		defer outfile.Close()
 	}
 
-	if _, err := outfile.Write(dataOut); err != nil {
+	if _, err := outfile.Write(append(dataOut, '\n')); err != nil {
 		fail("Failed to write config to %s: %v\n", outfile.Name(), err)
 	}
 }


### PR DESCRIPTION
Add a final newline to output, both with and without `--pretty`, to match Unix convention.