### PR TITLE
config/common: validate duplicate keys

### DIFF
--- a/config/v1_0/fcos.go
+++ b/config/v1_0/fcos.go
@@ -77,10 +77,17 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, repo
 		return nil, r, err
 	}
 
-	second := validate.Validate(final, "json")
-	common.TranslateReportPaths(&second, translations)
-	second.Correlate(contextTree)
-	r.Merge(second)
+	// Check for invalid duplicated keys.
+	dupsReport := validate.ValidateCustom(final, "json", ignvalidate.ValidateDups)
+	common.TranslateReportPaths(&dupsReport, translations)
+	dupsReport.Correlate(contextTree)
+	r.Merge(dupsReport)
+
+	// Validate JSON semantics.
+	jsonReport := validate.Validate(final, "json")
+	common.TranslateReportPaths(&jsonReport, translations)
+	jsonReport.Correlate(contextTree)
+	r.Merge(jsonReport)
 
 	if r.IsFatal() {
 		return nil, r, common.ErrInvalidGeneratedConfig

--- a/config/v1_1_exp/fcos.go
+++ b/config/v1_1_exp/fcos.go
@@ -77,10 +77,17 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, repo
 		return nil, r, err
 	}
 
-	second := validate.Validate(final, "json")
-	common.TranslateReportPaths(&second, translations)
-	second.Correlate(contextTree)
-	r.Merge(second)
+	// Check for invalid duplicated keys.
+	dupsReport := validate.ValidateCustom(final, "json", ignvalidate.ValidateDups)
+	common.TranslateReportPaths(&dupsReport, translations)
+	dupsReport.Correlate(contextTree)
+	r.Merge(dupsReport)
+
+	// Validate JSON semantics.
+	jsonReport := validate.Validate(final, "json")
+	common.TranslateReportPaths(&jsonReport, translations)
+	jsonReport.Correlate(contextTree)
+	r.Merge(jsonReport)
 
 	if r.IsFatal() {
 		return nil, r, common.ErrInvalidGeneratedConfig


### PR DESCRIPTION
This unifies the final validation step on the generated JSON config,
adding a duplicate check on keys which was previously missing and
only performed by Ignition.

Closes: https://github.com/coreos/fedora-coreos-tracker/issues/451