### PR TITLE
base/v0_2: include mount options in generated mount unit

### DIFF
--- a/base/v0_2_exp/translate.go
+++ b/base/v0_2_exp/translate.go
@@ -39,6 +39,13 @@ After=systemd-fsck@{{.Device}}
 Where={{.Path}}
 What={{.Device}}
 Type={{.Format}}
+{{- if .MountOptions }}
+Options=
+  {{- range $i, $opt := .MountOptions }}
+    {{- if $i }},{{ end }}
+    {{- $opt }}
+  {{- end }}
+{{- end }}
 
 [Install]
 RequiredBy=local-fs.target`))


### PR DESCRIPTION
Any mount options that should be applied by Ignition are probably relevant in the real root too.  If we're asked to generate a mount unit, copy them over.