### PR TITLE
Add MergeBytes to merge raw FCCs into raw Ignition

### DIFF
--- a/config/v1_0/fcos.go
+++ b/config/v1_0/fcos.go
@@ -22,6 +22,7 @@ import (
 	fcos_0_1 "github.com/coreos/fcct/distro/fcos/v0_1"
 	"github.com/coreos/fcct/translate"
 
+	"github.com/coreos/ignition/v2/config/v3_0"
 	"github.com/coreos/ignition/v2/config/v3_0/types"
 	ignvalidate "github.com/coreos/ignition/v2/config/validate"
 	"github.com/coreos/vcontext/path"
@@ -98,4 +99,22 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, repo
 
 	outbytes, err := common.Marshal(final, options.Pretty)
 	return outbytes, r, err
+}
+
+func MergeBytes(fragments [][]byte, options common.TranslateOptions) ([]byte, error) {
+	// merged Ignition Config
+	final := types.Config{}
+
+	for _, fragment := range fragments {
+		cfg := Config{}
+		_, err := common.Unmarshal(fragment, &cfg, options.Strict)
+		if err != nil {
+			return nil, err
+		}
+
+		fragmentIgn, _, _ := cfg.Translate(options)
+		v3_0.Merge(final, fragmentIgn)
+	}
+	outbytes, err := common.Marshal(final, options.Pretty)
+	return outbytes, err
 }

--- a/config/v1_1/fcos.go
+++ b/config/v1_1/fcos.go
@@ -22,6 +22,7 @@ import (
 	fcos_0_1 "github.com/coreos/fcct/distro/fcos/v0_1"
 	"github.com/coreos/fcct/translate"
 
+	"github.com/coreos/ignition/v2/config/v3_1"
 	"github.com/coreos/ignition/v2/config/v3_1/types"
 	ignvalidate "github.com/coreos/ignition/v2/config/validate"
 	"github.com/coreos/vcontext/path"
@@ -98,4 +99,22 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, repo
 
 	outbytes, err := common.Marshal(final, options.Pretty)
 	return outbytes, r, err
+}
+
+func MergeBytes(fragments [][]byte, options common.TranslateOptions) ([]byte, error) {
+	// merged Ignition Config
+	final := types.Config{}
+
+	for _, fragment := range fragments {
+		cfg := Config{}
+		_, err := common.Unmarshal(fragment, &cfg, options.Strict)
+		if err != nil {
+			return nil, err
+		}
+
+		fragmentIgn, _, _ := cfg.Translate(options)
+		v3_1.Merge(final, fragmentIgn)
+	}
+	outbytes, err := common.Marshal(final, options.Pretty)
+	return outbytes, err
 }

--- a/config/v1_2_exp/fcos.go
+++ b/config/v1_2_exp/fcos.go
@@ -22,6 +22,7 @@ import (
 	fcos_0_1 "github.com/coreos/fcct/distro/fcos/v0_1"
 	"github.com/coreos/fcct/translate"
 
+	"github.com/coreos/ignition/v2/config/v3_2_experimental"
 	"github.com/coreos/ignition/v2/config/v3_2_experimental/types"
 	ignvalidate "github.com/coreos/ignition/v2/config/validate"
 	"github.com/coreos/vcontext/path"
@@ -98,4 +99,22 @@ func TranslateBytes(input []byte, options common.TranslateOptions) ([]byte, repo
 
 	outbytes, err := common.Marshal(final, options.Pretty)
 	return outbytes, r, err
+}
+
+func MergeBytes(fragments [][]byte, options common.TranslateOptions) ([]byte, error) {
+	// merged Ignition Config
+	final := types.Config{}
+
+	for _, fragment := range fragments {
+		cfg := Config{}
+		_, err := common.Unmarshal(fragment, &cfg, options.Strict)
+		if err != nil {
+			return nil, err
+		}
+
+		fragmentIgn, _, _ := cfg.Translate(options)
+		v3_2_experimental.Merge(final, fragmentIgn)
+	}
+	outbytes, err := common.Marshal(final, options.Pretty)
+	return outbytes, err
 }


### PR DESCRIPTION
* Add MergeBytes functions to v1_X subpackages to perform Translation and Ignition Merge of fragments at a specific Ignition version
* Add getMerger to determine the right merger function to call based on the first fragment's variant and version
* Add MergeBytes to wrap actual merger function uses

TODO: Not yet verified / used
Related: https://github.com/coreos/fcct/issues/118