### PR TITLE
base: Make gzip auto-compression skipable

### DIFF
--- a/base/options.go
+++ b/base/options.go
@@ -15,5 +15,6 @@
 package base
 
 type TranslateOptions struct {
-	FilesDir string // allow embedding local files relative to this directory
+	FilesDir                  string // allow embedding local files relative to this directory
+	NoResourceAutoCompression bool   // skip automatic compression of inline/local resources
 }

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -140,7 +140,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 			return
 		}
 
-		src, gzipped, err := makeDataURL(contents, to.Compression)
+		src, gzipped, err := makeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -156,7 +156,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression)
+		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -171,7 +171,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 	return
 }
 
-func makeDataURL(contents []byte, currentCompression *string) (uri string, gzipped bool, err error) {
+func makeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
 	// try three different encodings, and select the smallest one
 
 	// URL-escaped, useful for ASCII text
@@ -187,7 +187,7 @@ func makeDataURL(contents []byte, currentCompression *string) (uri string, gzipp
 	// user already enabled compression, don't compress again.
 	// We don't try base64-encoded URL-escaped because gzipped data is
 	// binary and URL escaping is unlikely to be efficient.
-	if currentCompression == nil || *currentCompression == "" {
+	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
 		var buf bytes.Buffer
 		var compressor *gzip.Writer
 		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
@@ -320,7 +320,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := makeDataURL(contents, file.Contents.Compression)
+			url, gzipped, err := makeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -255,6 +255,7 @@ func TestTranslateFile(t *testing.T) {
 			File{
 				Path: "/foo",
 				Contents: Resource{
+					// String is too short for auto gzip compression
 					Inline: util.StrToPtr("xyzzy"),
 				},
 			},
@@ -462,6 +463,35 @@ func TestTranslateFile(t *testing.T) {
 			"",
 			base.TranslateOptions{
 				FilesDir: filesDir,
+			},
+		},
+		// Test disable automatic gzip compression
+		{
+			File{
+				Path: "/foo",
+				Contents: Resource{
+					Inline: util.StrToPtr(zzz),
+				},
+			},
+			types.File{
+				Node: types.Node{
+					Path: "/foo",
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					Contents: types.Resource{
+						Source: util.StrToPtr("data:," + zzz),
+					},
+				},
+			},
+			[]translate.Translation{
+				{
+					From: path.New("yaml", "contents", "inline"),
+					To:   path.New("json", "contents", "source"),
+				},
+			},
+			"",
+			base.TranslateOptions{
+				NoResourceAutoCompression: true,
 			},
 		},
 	}

--- a/base/v0_3_exp/translate.go
+++ b/base/v0_3_exp/translate.go
@@ -140,7 +140,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 			return
 		}
 
-		src, gzipped, err := makeDataURL(contents, to.Compression)
+		src, gzipped, err := makeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -156,7 +156,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression)
+		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -171,7 +171,7 @@ func translateResource(from Resource, options base.TranslateOptions) (to types.R
 	return
 }
 
-func makeDataURL(contents []byte, currentCompression *string) (uri string, gzipped bool, err error) {
+func makeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
 	// try three different encodings, and select the smallest one
 
 	// URL-escaped, useful for ASCII text
@@ -187,7 +187,7 @@ func makeDataURL(contents []byte, currentCompression *string) (uri string, gzipp
 	// user already enabled compression, don't compress again.
 	// We don't try base64-encoded URL-escaped because gzipped data is
 	// binary and URL escaping is unlikely to be efficient.
-	if currentCompression == nil || *currentCompression == "" {
+	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
 		var buf bytes.Buffer
 		var compressor *gzip.Writer
 		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
@@ -320,7 +320,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := makeDataURL(contents, file.Contents.Compression)
+			url, gzipped, err := makeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_3_exp/translate_test.go
+++ b/base/v0_3_exp/translate_test.go
@@ -255,6 +255,7 @@ func TestTranslateFile(t *testing.T) {
 			File{
 				Path: "/foo",
 				Contents: Resource{
+					// String is too short for auto gzip compression
 					Inline: util.StrToPtr("xyzzy"),
 				},
 			},
@@ -462,6 +463,35 @@ func TestTranslateFile(t *testing.T) {
 			"",
 			base.TranslateOptions{
 				FilesDir: filesDir,
+			},
+		},
+		// Test disable automatic gzip compression
+		{
+			File{
+				Path: "/foo",
+				Contents: Resource{
+					Inline: util.StrToPtr(zzz),
+				},
+			},
+			types.File{
+				Node: types.Node{
+					Path: "/foo",
+				},
+				FileEmbedded1: types.FileEmbedded1{
+					Contents: types.Resource{
+						Source: util.StrToPtr("data:," + zzz),
+					},
+				},
+			},
+			[]translate.Translation{
+				{
+					From: path.New("yaml", "contents", "inline"),
+					To:   path.New("json", "contents", "source"),
+				},
+			},
+			"",
+			base.TranslateOptions{
+				NoResourceAutoCompression: true,
 			},
 		},
 	}


### PR DESCRIPTION
Fixes: https://github.com/coreos/fcct/issues/123

If this is agreeable, can we also port it back to v0.2?