### PR TITLE
release-checklist: update tagging and GitHub release instructions

### DIFF
--- a/.github/ISSUE_TEMPLATE/release-checklist.md
+++ b/.github/ISSUE_TEMPLATE/release-checklist.md
@@ -3,7 +3,8 @@ Release checklist:
 Tagging:
  - [ ] Write release notes in NEWS. Get them reviewed and merged
      - [ ] If doing a branched release, also include a PR to merge the NEWS changes into master
- - [ ] Ensure your local copy is up to date with master and your working directory is clean
+ - [ ] Ensure your local copy is up to date with the upstream master branch (`git@github.com:coreos/fcct.git`)
+ - [ ] Ensure your working directory is clean (`git clean -fdx`)
  - [ ] Ensure you can sign commits and any yubikeys/smartcards are plugged in
  - [ ] Run `./tag_release.sh <vX.Y.z> <git commit hash>`
  - [ ] Push that tag to GitHub
@@ -37,7 +38,8 @@ GitHub release:
  - [ ] Wait for the ticket to be closed
  - [ ] Download the artifacts and signatures
  - [ ] Verify the signatures
- - [ ] Create a [draft release](https://github.com/coreos/fcct/releases/new) on GitHub and upload all the release artifacts and their signatures. Copy and paste the release notes from NEWS here as well.
+ - [ ] Find the new tag in the [GitHub tag list](https://github.com/coreos/fcct/tags) and click the triple dots menu, and create a draft release for it.
+ - [ ] Upload all the release artifacts and their signatures. Copy and paste the release notes from NEWS here as well.
  - [ ] Publish the release
 
 Quay release:


### PR DESCRIPTION
This will update the release instructions to provide some information around the `master` branch reference and clarify the step while publishing a release.