### PR TITLE
base: Move spec-independent code to a utility package

### DIFF
--- a/base/util/file.go
+++ b/base/util/file.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package util
+
+import (
+	"path/filepath"
+	"strings"
+
+	"github.com/coreos/fcct/config/common"
+)
+
+func EnsurePathWithinFilesDir(path, filesDir string) error {
+	absBase, err := filepath.Abs(filesDir)
+	if err != nil {
+		return err
+	}
+	absPath, err := filepath.Abs(path)
+	if err != nil {
+		return err
+	}
+	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
+		return common.ErrFilesDirEscape
+	}
+	return nil
+}

--- a/base/util/test.go
+++ b/base/util/test.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package util
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/coreos/fcct/translate"
+
+	"github.com/clarketm/json"
+)
+
+// helper functions for writing tests
+
+// VerifyTranslations ensures all the translations are identity, unless they
+// match a listed one, and verifies that all the listed ones exist.
+// it returns the offending translation if there is one
+func VerifyTranslations(set translate.TranslationSet, exceptions ...translate.Translation) *translate.Translation {
+	exceptionSet := translate.TranslationSet{
+		FromTag: set.FromTag,
+		ToTag:   set.ToTag,
+		Set:     map[string]translate.Translation{},
+	}
+	for _, ex := range exceptions {
+		exceptionSet.AddTranslation(ex.From, ex.To)
+		if tr, ok := set.Set[ex.To.String()]; ok {
+			if !reflect.DeepEqual(tr, ex) {
+				return &ex
+			}
+		} else {
+			return &ex
+		}
+	}
+	for key, translation := range set.Set {
+		if ex, ok := exceptionSet.Set[key]; ok {
+			if !reflect.DeepEqual(translation, ex) {
+				return &ex
+			}
+		} else if !reflect.DeepEqual(translation.From.Path, translation.To.Path) {
+			return &translation
+		}
+	}
+	return nil
+}
+
+/// FormatJSON serializes the input to formatted JSON for display when a
+/// test fails
+func FormatJSON(from interface{}) string {
+	buf, err := json.MarshalIndent(from, "", "  ")
+	if err != nil {
+		return fmt.Sprintf("<Error marshaling to JSON: %v>", err)
+	}
+	return string(buf)
+}

--- a/base/util/url.go
+++ b/base/util/url.go
@@ -23,7 +23,7 @@ import (
 	"github.com/vincent-petithory/dataurl"
 )
 
-func MakeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
+func MakeDataURL(contents []byte, currentCompression *string, allowCompression bool) (uri string, gzipped bool, err error) {
 	// try three different encodings, and select the smallest one
 
 	// URL-escaped, useful for ASCII text
@@ -39,7 +39,7 @@ func MakeDataURL(contents []byte, currentCompression *string, noResourceAutoComp
 	// user already enabled compression, don't compress again.
 	// We don't try base64-encoded URL-escaped because gzipped data is
 	// binary and URL escaping is unlikely to be efficient.
-	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
+	if (currentCompression == nil || *currentCompression == "") && allowCompression {
 		var buf bytes.Buffer
 		var compressor *gzip.Writer
 		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {

--- a/base/util/url.go
+++ b/base/util/url.go
@@ -1,0 +1,67 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package util
+
+import (
+	"bytes"
+	"compress/gzip"
+	"encoding/base64"
+	"net/url"
+
+	"github.com/vincent-petithory/dataurl"
+)
+
+func MakeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
+	// try three different encodings, and select the smallest one
+
+	// URL-escaped, useful for ASCII text
+	opaque := "," + dataurl.Escape(contents)
+
+	// Base64-encoded, useful for small or incompressible binary data
+	b64 := ";base64," + base64.StdEncoding.EncodeToString(contents)
+	if len(b64) < len(opaque) {
+		opaque = b64
+	}
+
+	// Base64-encoded gzipped, useful for compressible data.  If the
+	// user already enabled compression, don't compress again.
+	// We don't try base64-encoded URL-escaped because gzipped data is
+	// binary and URL escaping is unlikely to be efficient.
+	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
+		var buf bytes.Buffer
+		var compressor *gzip.Writer
+		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
+			return
+		}
+		if _, err = compressor.Write(contents); err != nil {
+			return
+		}
+		if err = compressor.Close(); err != nil {
+			return
+		}
+		gz := ";base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
+		// Account for space needed by "compression": "gzip".
+		if len(gz)+25 < len(opaque) {
+			opaque = gz
+			gzipped = true
+		}
+	}
+
+	uri = (&url.URL{
+		Scheme: "data",
+		Opaque: opaque,
+	}).String()
+	return
+}

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
@@ -27,29 +28,6 @@ import (
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
-
-// verifyTranslations ensures all the translations are identity, unless they match a listed one
-// it returns the offending translation if there is one
-func verifyTranslations(set translate.TranslationSet, exceptions ...translate.Translation) *translate.Translation {
-	exceptionSet := translate.TranslationSet{
-		FromTag: set.FromTag,
-		ToTag:   set.ToTag,
-		Set:     map[string]translate.Translation{},
-	}
-	for _, ex := range exceptions {
-		exceptionSet.AddTranslation(ex.From, ex.To)
-	}
-	for key, translation := range set.Set {
-		if ex, ok := exceptionSet.Set[key]; ok {
-			if !reflect.DeepEqual(translation, ex) {
-				return &ex
-			}
-		} else if !reflect.DeepEqual(translation.From.Path, translation.To.Path) {
-			return &translation
-		}
-	}
-	return nil
-}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -162,7 +140,7 @@ func TestTranslateFile(t *testing.T) {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
 		}
 
-		if errT := verifyTranslations(translations, test.exceptions...); errT != nil {
+		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
 			t.Errorf("#%d: bad translation: %v", i, *errT)
 		}
 	}

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -15,16 +15,13 @@
 package v0_2
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
@@ -33,7 +30,6 @@ import (
 	"github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
-	"github.com/vincent-petithory/dataurl"
 )
 
 var (
@@ -141,7 +137,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := makeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -157,7 +153,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -169,49 +165,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			tm.AddTranslation(c, path.New("json", "compression"))
 		}
 	}
-	return
-}
-
-func makeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
-	// try three different encodings, and select the smallest one
-
-	// URL-escaped, useful for ASCII text
-	opaque := "," + dataurl.Escape(contents)
-
-	// Base64-encoded, useful for small or incompressible binary data
-	b64 := ";base64," + base64.StdEncoding.EncodeToString(contents)
-	if len(b64) < len(opaque) {
-		opaque = b64
-	}
-
-	// Base64-encoded gzipped, useful for compressible data.  If the
-	// user already enabled compression, don't compress again.
-	// We don't try base64-encoded URL-escaped because gzipped data is
-	// binary and URL escaping is unlikely to be efficient.
-	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
-		var buf bytes.Buffer
-		var compressor *gzip.Writer
-		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
-			return
-		}
-		if _, err = compressor.Write(contents); err != nil {
-			return
-		}
-		if err = compressor.Close(); err != nil {
-			return
-		}
-		gz := ";base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
-		// Account for space needed by "compression": "gzip".
-		if len(gz)+25 < len(opaque) {
-			opaque = gz
-			gzipped = true
-		}
-	}
-
-	uri = (&url.URL{
-		Scheme: "data",
-		Opaque: opaque,
-	}).String()
 	return
 }
 
@@ -321,7 +274,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := makeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -126,7 +126,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		// calculate file path within FilesDir and check for
 		// path traversal
 		filePath := filepath.Join(options.FilesDir, *from.Local)
-		if err := ensurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
 		}
@@ -209,7 +209,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 		// calculate base path within FilesDir and check for
 		// path traversal
 		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
-		if err := ensurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
 		}
@@ -377,19 +377,4 @@ func mountUnitFromFS(fs Filesystem) types.Unit {
 		Enabled:  util.BoolToPtr(true),
 		Contents: util.StrToPtr(contents.String()),
 	}
-}
-
-func ensurePathWithinFilesDir(path, filesDir string) error {
-	absBase, err := filepath.Abs(filesDir)
-	if err != nil {
-		return err
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
-		return common.ErrFilesDirEscape
-	}
-	return nil
 }

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -137,7 +137,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -153,7 +153,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -274,7 +274,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_2/validate_test.go
+++ b/base/v0_2/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -132,7 +133,7 @@ func TestValidateResource(t *testing.T) {
 		expected.AddOnError(test.errPath, test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }
@@ -154,7 +155,7 @@ func TestValidateTree(t *testing.T) {
 		expected.AddOnError(path.New("yaml"), test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -149,7 +149,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		// calculate file path within FilesDir and check for
 		// path traversal
 		filePath := filepath.Join(options.FilesDir, *from.Local)
-		if err := ensurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
 		}
@@ -232,7 +232,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 		// calculate base path within FilesDir and check for
 		// path traversal
 		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
-		if err := ensurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
 		}
@@ -419,19 +419,4 @@ func mountUnitFromFS(fs Filesystem, remote bool) types.Unit {
 		Enabled:  util.BoolToPtr(true),
 		Contents: util.StrToPtr(contents.String()),
 	}
-}
-
-func ensurePathWithinFilesDir(path, filesDir string) error {
-	absBase, err := filepath.Abs(filesDir)
-	if err != nil {
-		return err
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
-		return common.ErrFilesDirEscape
-	}
-	return nil
 }

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -15,17 +15,14 @@
 package v0_3
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
@@ -34,7 +31,6 @@ import (
 	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
-	"github.com/vincent-petithory/dataurl"
 )
 
 var (
@@ -164,7 +160,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := makeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -180,7 +176,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -192,49 +188,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			tm.AddTranslation(c, path.New("json", "compression"))
 		}
 	}
-	return
-}
-
-func makeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
-	// try three different encodings, and select the smallest one
-
-	// URL-escaped, useful for ASCII text
-	opaque := "," + dataurl.Escape(contents)
-
-	// Base64-encoded, useful for small or incompressible binary data
-	b64 := ";base64," + base64.StdEncoding.EncodeToString(contents)
-	if len(b64) < len(opaque) {
-		opaque = b64
-	}
-
-	// Base64-encoded gzipped, useful for compressible data.  If the
-	// user already enabled compression, don't compress again.
-	// We don't try base64-encoded URL-escaped because gzipped data is
-	// binary and URL escaping is unlikely to be efficient.
-	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
-		var buf bytes.Buffer
-		var compressor *gzip.Writer
-		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
-			return
-		}
-		if _, err = compressor.Write(contents); err != nil {
-			return
-		}
-		if err = compressor.Close(); err != nil {
-			return
-		}
-		gz := ";base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
-		// Account for space needed by "compression": "gzip".
-		if len(gz)+25 < len(opaque) {
-			opaque = gz
-			gzipped = true
-		}
-	}
-
-	uri = (&url.URL{
-		Scheme: "data",
-		Opaque: opaque,
-	}).String()
 	return
 }
 
@@ -344,7 +297,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := makeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -160,7 +160,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -176,7 +176,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -297,7 +297,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_3/translate_test.go
+++ b/base/v0_3/translate_test.go
@@ -15,7 +15,6 @@
 package v0_3
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -24,55 +23,16 @@ import (
 	"strings"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
-	"github.com/clarketm/json"
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/path"
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
-
-func format(from interface{}) string {
-	buf, err := json.MarshalIndent(from, "", "  ")
-	if err != nil {
-		return fmt.Sprintf("<Error marshaling to JSON: %v>", err)
-	}
-	return string(buf)
-}
-
-// verifyTranslations ensures all the translations are identity, unless they match a listed one,
-// and verifies that all the listed ones exist.
-// it returns the offending translation if there is one
-func verifyTranslations(set translate.TranslationSet, exceptions ...translate.Translation) *translate.Translation {
-	exceptionSet := translate.TranslationSet{
-		FromTag: set.FromTag,
-		ToTag:   set.ToTag,
-		Set:     map[string]translate.Translation{},
-	}
-	for _, ex := range exceptions {
-		exceptionSet.AddTranslation(ex.From, ex.To)
-		if tr, ok := set.Set[ex.To.String()]; ok {
-			if !reflect.DeepEqual(tr, ex) {
-				return &ex
-			}
-		} else {
-			return &ex
-		}
-	}
-	for key, translation := range set.Set {
-		if ex, ok := exceptionSet.Set[key]; ok {
-			if !reflect.DeepEqual(translation, ex) {
-				return &ex
-			}
-		} else if !reflect.DeepEqual(translation.From.Path, translation.To.Path) {
-			return &translation
-		}
-	}
-	return nil
-}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -500,14 +460,14 @@ func TestTranslateFile(t *testing.T) {
 		actual, translations, report := translateFile(test.in, test.options)
 
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 
 		if report.String() != test.report {
 			t.Errorf("#%d: expected report '%+v', got '%+v'", i, test.report, report.String())
 		}
 
-		if errT := verifyTranslations(translations, test.exceptions...); errT != nil {
+		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
 			t.Errorf("#%d: bad translation: %v", i, *errT)
 		}
 	}
@@ -562,7 +522,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateDirectory(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -621,7 +581,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateLink(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -677,7 +637,7 @@ func TestTranslateFilesystem(t *testing.T) {
 		expected := []types.Filesystem{test.out}
 		actual, _, report := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
 		if !reflect.DeepEqual(actual.Storage.Filesystems, expected) {
-			t.Errorf("#%d: expected %v, got %v", i, format(expected), format(actual.Storage.Filesystems))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual.Storage.Filesystems))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -1131,15 +1091,15 @@ func TestTranslateTree(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(actual.Storage.Files, test.outFiles) {
-			t.Errorf("#%d: expected files %v, got %v", i, format(test.outFiles), format(actual.Storage.Files))
+			t.Errorf("#%d: expected files %v, got %v", i, baseutil.FormatJSON(test.outFiles), baseutil.FormatJSON(actual.Storage.Files))
 		}
 
 		if len(actual.Storage.Directories) != 0 {
-			t.Errorf("#%d: expected empty directories, got %v", i, format(actual.Storage.Directories))
+			t.Errorf("#%d: expected empty directories, got %v", i, baseutil.FormatJSON(actual.Storage.Directories))
 		}
 
 		if !reflect.DeepEqual(actual.Storage.Links, test.outLinks) {
-			t.Errorf("#%d: expected links %v, got %v", i, format(test.outLinks), format(actual.Storage.Links))
+			t.Errorf("#%d: expected links %v, got %v", i, baseutil.FormatJSON(test.outLinks), baseutil.FormatJSON(actual.Storage.Links))
 		}
 	}
 }
@@ -1228,7 +1188,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateIgnition(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -1258,7 +1218,7 @@ func TestToIgn3_2(t *testing.T) {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
 		}
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 	}
 }

--- a/base/v0_3/validate_test.go
+++ b/base/v0_3/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -132,7 +133,7 @@ func TestValidateResource(t *testing.T) {
 		expected.AddOnError(test.errPath, test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }
@@ -154,7 +155,7 @@ func TestValidateTree(t *testing.T) {
 		expected.AddOnError(path.New("yaml"), test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -149,7 +149,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 		// calculate file path within FilesDir and check for
 		// path traversal
 		filePath := filepath.Join(options.FilesDir, *from.Local)
-		if err := ensurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(filePath, options.FilesDir); err != nil {
 			r.AddOnError(c, err)
 			return
 		}
@@ -232,7 +232,7 @@ func (c Config) processTrees(ret *types.Config, options common.TranslateOptions)
 		// calculate base path within FilesDir and check for
 		// path traversal
 		srcBaseDir := filepath.Join(options.FilesDir, tree.Local)
-		if err := ensurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
+		if err := baseutil.EnsurePathWithinFilesDir(srcBaseDir, options.FilesDir); err != nil {
 			r.AddOnError(yamlPath, err)
 			continue
 		}
@@ -419,19 +419,4 @@ func mountUnitFromFS(fs Filesystem, remote bool) types.Unit {
 		Enabled:  util.BoolToPtr(true),
 		Contents: util.StrToPtr(contents.String()),
 	}
-}
-
-func ensurePathWithinFilesDir(path, filesDir string) error {
-	absBase, err := filepath.Abs(filesDir)
-	if err != nil {
-		return err
-	}
-	absPath, err := filepath.Abs(path)
-	if err != nil {
-		return err
-	}
-	if !strings.HasPrefix(absPath, absBase+string(filepath.Separator)) {
-		return common.ErrFilesDirEscape
-	}
-	return nil
 }

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -15,17 +15,14 @@
 package v0_4_exp
 
 import (
-	"bytes"
-	"compress/gzip"
-	"encoding/base64"
 	"fmt"
 	"io/ioutil"
-	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
@@ -34,7 +31,6 @@ import (
 	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
-	"github.com/vincent-petithory/dataurl"
 )
 
 var (
@@ -164,7 +160,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := makeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -180,7 +176,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := makeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -192,49 +188,6 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			tm.AddTranslation(c, path.New("json", "compression"))
 		}
 	}
-	return
-}
-
-func makeDataURL(contents []byte, currentCompression *string, noResourceAutoCompression bool) (uri string, gzipped bool, err error) {
-	// try three different encodings, and select the smallest one
-
-	// URL-escaped, useful for ASCII text
-	opaque := "," + dataurl.Escape(contents)
-
-	// Base64-encoded, useful for small or incompressible binary data
-	b64 := ";base64," + base64.StdEncoding.EncodeToString(contents)
-	if len(b64) < len(opaque) {
-		opaque = b64
-	}
-
-	// Base64-encoded gzipped, useful for compressible data.  If the
-	// user already enabled compression, don't compress again.
-	// We don't try base64-encoded URL-escaped because gzipped data is
-	// binary and URL escaping is unlikely to be efficient.
-	if (currentCompression == nil || *currentCompression == "") && !noResourceAutoCompression {
-		var buf bytes.Buffer
-		var compressor *gzip.Writer
-		if compressor, err = gzip.NewWriterLevel(&buf, gzip.BestCompression); err != nil {
-			return
-		}
-		if _, err = compressor.Write(contents); err != nil {
-			return
-		}
-		if err = compressor.Close(); err != nil {
-			return
-		}
-		gz := ";base64," + base64.StdEncoding.EncodeToString(buf.Bytes())
-		// Account for space needed by "compression": "gzip".
-		if len(gz)+25 < len(opaque) {
-			opaque = gz
-			gzipped = true
-		}
-	}
-
-	uri = (&url.URL{
-		Scheme: "data",
-		Opaque: opaque,
-	}).String()
 	return
 }
 
@@ -344,7 +297,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := makeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -160,7 +160,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 			return
 		}
 
-		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL(contents, to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -176,7 +176,7 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	if from.Inline != nil {
 		c := path.New("yaml", "inline")
 
-		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, options.NoResourceAutoCompression)
+		src, gzipped, err := baseutil.MakeDataURL([]byte(*from.Inline), to.Compression, !options.NoResourceAutoCompression)
 		if err != nil {
 			r.AddOnError(c, err)
 			return
@@ -297,7 +297,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				r.AddOnError(yamlPath, err)
 				return nil
 			}
-			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, options.NoResourceAutoCompression)
+			url, gzipped, err := baseutil.MakeDataURL(contents, file.Contents.Compression, !options.NoResourceAutoCompression)
 			if err != nil {
 				r.AddOnError(yamlPath, err)
 				return nil

--- a/base/v0_4_exp/translate_test.go
+++ b/base/v0_4_exp/translate_test.go
@@ -15,7 +15,6 @@
 package v0_4_exp
 
 import (
-	"fmt"
 	"io/ioutil"
 	"net"
 	"os"
@@ -24,55 +23,16 @@ import (
 	"strings"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	"github.com/coreos/fcct/translate"
 
-	"github.com/clarketm/json"
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 	"github.com/coreos/vcontext/path"
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
-
-func format(from interface{}) string {
-	buf, err := json.MarshalIndent(from, "", "  ")
-	if err != nil {
-		return fmt.Sprintf("<Error marshaling to JSON: %v>", err)
-	}
-	return string(buf)
-}
-
-// verifyTranslations ensures all the translations are identity, unless they match a listed one,
-// and verifies that all the listed ones exist.
-// it returns the offending translation if there is one
-func verifyTranslations(set translate.TranslationSet, exceptions ...translate.Translation) *translate.Translation {
-	exceptionSet := translate.TranslationSet{
-		FromTag: set.FromTag,
-		ToTag:   set.ToTag,
-		Set:     map[string]translate.Translation{},
-	}
-	for _, ex := range exceptions {
-		exceptionSet.AddTranslation(ex.From, ex.To)
-		if tr, ok := set.Set[ex.To.String()]; ok {
-			if !reflect.DeepEqual(tr, ex) {
-				return &ex
-			}
-		} else {
-			return &ex
-		}
-	}
-	for key, translation := range set.Set {
-		if ex, ok := exceptionSet.Set[key]; ok {
-			if !reflect.DeepEqual(translation, ex) {
-				return &ex
-			}
-		} else if !reflect.DeepEqual(translation.From.Path, translation.To.Path) {
-			return &translation
-		}
-	}
-	return nil
-}
 
 // TestTranslateFile tests translating the ct storage.files.[i] entries to ignition storage.files.[i] entries.
 func TestTranslateFile(t *testing.T) {
@@ -500,14 +460,14 @@ func TestTranslateFile(t *testing.T) {
 		actual, translations, report := translateFile(test.in, test.options)
 
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 
 		if report.String() != test.report {
 			t.Errorf("#%d: expected report '%+v', got '%+v'", i, test.report, report.String())
 		}
 
-		if errT := verifyTranslations(translations, test.exceptions...); errT != nil {
+		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
 			t.Errorf("#%d: bad translation: %v", i, *errT)
 		}
 	}
@@ -562,7 +522,7 @@ func TestTranslateDirectory(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateDirectory(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -621,7 +581,7 @@ func TestTranslateLink(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateLink(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -677,7 +637,7 @@ func TestTranslateFilesystem(t *testing.T) {
 		expected := []types.Filesystem{test.out}
 		actual, _, report := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
 		if !reflect.DeepEqual(actual.Storage.Filesystems, expected) {
-			t.Errorf("#%d: expected %v, got %v", i, format(expected), format(actual.Storage.Filesystems))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual.Storage.Filesystems))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -1131,15 +1091,15 @@ func TestTranslateTree(t *testing.T) {
 		}
 
 		if !reflect.DeepEqual(actual.Storage.Files, test.outFiles) {
-			t.Errorf("#%d: expected files %v, got %v", i, format(test.outFiles), format(actual.Storage.Files))
+			t.Errorf("#%d: expected files %v, got %v", i, baseutil.FormatJSON(test.outFiles), baseutil.FormatJSON(actual.Storage.Files))
 		}
 
 		if len(actual.Storage.Directories) != 0 {
-			t.Errorf("#%d: expected empty directories, got %v", i, format(actual.Storage.Directories))
+			t.Errorf("#%d: expected empty directories, got %v", i, baseutil.FormatJSON(actual.Storage.Directories))
 		}
 
 		if !reflect.DeepEqual(actual.Storage.Links, test.outLinks) {
-			t.Errorf("#%d: expected links %v, got %v", i, format(test.outLinks), format(actual.Storage.Links))
+			t.Errorf("#%d: expected links %v, got %v", i, baseutil.FormatJSON(test.outLinks), baseutil.FormatJSON(actual.Storage.Links))
 		}
 	}
 }
@@ -1228,7 +1188,7 @@ func TestTranslateIgnition(t *testing.T) {
 	for i, test := range tests {
 		actual, _, report := translateIgnition(test.in, common.TranslateOptions{})
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 		if report.String() != "" {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
@@ -1258,7 +1218,7 @@ func TestToIgn3_3(t *testing.T) {
 			t.Errorf("#%d: got non-empty report: %v", i, report.String())
 		}
 		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, format(test.out), format(actual))
+			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
 		}
 	}
 }

--- a/base/v0_4_exp/validate_test.go
+++ b/base/v0_4_exp/validate_test.go
@@ -18,6 +18,7 @@ import (
 	"reflect"
 	"testing"
 
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
@@ -132,7 +133,7 @@ func TestValidateResource(t *testing.T) {
 		expected.AddOnError(test.errPath, test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }
@@ -154,7 +155,7 @@ func TestValidateTree(t *testing.T) {
 		expected.AddOnError(path.New("yaml"), test.out)
 
 		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, format(expected), format(actual))
+			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
 		}
 	}
 }


### PR DESCRIPTION
Stop copying spec-independent utility code every time we stabilize a base package.  Each of these functions is potentially useful to outside code, so put them in a `util` package rather than `internal`.