### PR TITLE
base: warn if file/dir modes appear to have been specified in decimal

### DIFF
--- a/base/util/file_test.go
+++ b/base/util/file_test.go
@@ -1,0 +1,125 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package util
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	expectedBadDirModes = []int{
+		500,  // 0764
+		550,  // 01046
+		555,  // 01053
+		700,  // 01274
+		750,  // 01356
+		755,  // 01363
+		770,  // 01402
+		775,  // 01407
+		777,  // 01411
+		1700, // 03244
+		1750, // 03326
+		1755, // 03333
+		1770, // 03352
+		1775, // 03357
+		1777, // 03361
+		2700, // 05214
+		2750, // 05276
+		2755, // 05303
+		2770, // 05322
+		2775, // 05327
+		2777, // 05331
+		3700, // 07164
+		3750, // 07246
+		3755, // 07253
+		3770, // 07272
+		3775, // 07277
+		3777, // 07301
+	}
+	expectedBadFileModes = []int{
+		400,  // 0620
+		440,  // 0670
+		444,  // 0674
+		500,  // 0764
+		550,  // 01046
+		555,  // 01053
+		600,  // 01130
+		640,  // 01200
+		644,  // 01204
+		660,  // 01224
+		664,  // 01230
+		666,  // 01232
+		700,  // 01274
+		750,  // 01356
+		755,  // 01363
+		770,  // 01402
+		775,  // 01407
+		777,  // 01411
+		2500, // 04704
+		2550, // 04766
+		2555, // 04773
+		2700, // 05214
+		2750, // 05276
+		2755, // 05303
+		2770, // 05322
+		2775, // 05327
+		4500, // 010624
+		4550, // 010706
+		4555, // 010713
+		4700, // 011134
+		4750, // 011216
+		4755, // 011223
+		4770, // 011242
+		4775, // 011247
+		6500, // 014544
+		6550, // 014626
+		6555, // 014633
+		6700, // 015054
+		6750, // 015136
+		6755, // 015143
+		6770, // 015162
+		6775, // 015167
+	}
+)
+
+func TestCheckForDecimalMode(t *testing.T) {
+	// test decimal to octal conversion
+	for i := -1; i < 10001; i++ {
+		iStr := fmt.Sprintf("%d", i)
+		result, ok := decimalModeToOctal(i)
+		assert.Equal(t, i >= 0 && i <= 7777 && !strings.ContainsAny(iStr, "89"), ok, "converting %d to octal returned incorrect ok", i)
+		if ok {
+			assert.Equal(t, iStr, fmt.Sprintf("%o", result), "converting %d to octal failed", i)
+		}
+	}
+
+	// check the checker against a hardcoded list
+	var badDirModes []int
+	var badFileModes []int
+	for i := -1; i <= 10000; i++ {
+		if CheckForDecimalMode(i, true) != nil {
+			badDirModes = append(badDirModes, i)
+		}
+		if CheckForDecimalMode(i, false) != nil {
+			badFileModes = append(badFileModes, i)
+		}
+	}
+	assert.Equal(t, expectedBadDirModes, badDirModes, "bad set of decimal directory modes")
+	assert.Equal(t, expectedBadFileModes, badFileModes, "bad set of decimal file modes")
+}

--- a/base/v0_1/validate.go
+++ b/base/v0_1/validate.go
@@ -15,6 +15,7 @@
 package v0_1
 
 import (
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/vcontext/path"
@@ -24,6 +25,20 @@ import (
 func (f FileContents) Validate(c path.ContextPath) (r report.Report) {
 	if f.Inline != nil && f.Source != nil {
 		r.AddOnError(c.Append("inline"), common.ErrTooManyResourceSources)
+	}
+	return
+}
+
+func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	if d.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*d.Mode, true))
+	}
+	return
+}
+
+func (f File) Validate(c path.ContextPath) (r report.Report) {
+	if f.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*f.Mode, false))
 	}
 	return
 }

--- a/base/v0_1/validate_test.go
+++ b/base/v0_1/validate_test.go
@@ -76,3 +76,63 @@ func TestValidateFileContents(t *testing.T) {
 		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
+
+func TestValidateMode(t *testing.T) {
+	fileTests := []struct {
+		in  File
+		out error
+	}{
+		{
+			in:  File{},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(0600),
+			},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(600),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range fileTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+
+	dirTests := []struct {
+		in  Directory
+		out error
+	}{
+		{
+			in:  Directory{},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(01770),
+			},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(1770),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range dirTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+}

--- a/base/v0_2/validate.go
+++ b/base/v0_2/validate.go
@@ -15,6 +15,7 @@
 package v0_2
 
 import (
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/vcontext/path"
@@ -51,6 +52,20 @@ func (fs Filesystem) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if fs.Format == nil || *fs.Format == "" {
 		r.AddOnError(c.Append("format"), common.ErrMountUnitNoFormat)
+	}
+	return
+}
+
+func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	if d.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*d.Mode, true))
+	}
+	return
+}
+
+func (f File) Validate(c path.ContextPath) (r report.Report) {
+	if f.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*f.Mode, false))
 	}
 	return
 }

--- a/base/v0_2/validate_test.go
+++ b/base/v0_2/validate_test.go
@@ -152,3 +152,63 @@ func TestValidateTree(t *testing.T) {
 		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
+
+func TestValidateMode(t *testing.T) {
+	fileTests := []struct {
+		in  File
+		out error
+	}{
+		{
+			in:  File{},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(0600),
+			},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(600),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range fileTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+
+	dirTests := []struct {
+		in  Directory
+		out error
+	}{
+		{
+			in:  Directory{},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(01770),
+			},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(1770),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range dirTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+}

--- a/base/v0_3/validate.go
+++ b/base/v0_3/validate.go
@@ -15,6 +15,7 @@
 package v0_3
 
 import (
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/vcontext/path"
@@ -51,6 +52,20 @@ func (fs Filesystem) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if fs.Format == nil || *fs.Format == "" {
 		r.AddOnError(c.Append("format"), common.ErrMountUnitNoFormat)
+	}
+	return
+}
+
+func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	if d.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*d.Mode, true))
+	}
+	return
+}
+
+func (f File) Validate(c path.ContextPath) (r report.Report) {
+	if f.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*f.Mode, false))
 	}
 	return
 }

--- a/base/v0_3/validate_test.go
+++ b/base/v0_3/validate_test.go
@@ -152,3 +152,63 @@ func TestValidateTree(t *testing.T) {
 		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
+
+func TestValidateMode(t *testing.T) {
+	fileTests := []struct {
+		in  File
+		out error
+	}{
+		{
+			in:  File{},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(0600),
+			},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(600),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range fileTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+
+	dirTests := []struct {
+		in  Directory
+		out error
+	}{
+		{
+			in:  Directory{},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(01770),
+			},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(1770),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range dirTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+}

--- a/base/v0_4_exp/validate.go
+++ b/base/v0_4_exp/validate.go
@@ -15,6 +15,7 @@
 package v0_4_exp
 
 import (
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/vcontext/path"
@@ -51,6 +52,20 @@ func (fs Filesystem) Validate(c path.ContextPath) (r report.Report) {
 	}
 	if fs.Format == nil || *fs.Format == "" {
 		r.AddOnError(c.Append("format"), common.ErrMountUnitNoFormat)
+	}
+	return
+}
+
+func (d Directory) Validate(c path.ContextPath) (r report.Report) {
+	if d.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*d.Mode, true))
+	}
+	return
+}
+
+func (f File) Validate(c path.ContextPath) (r report.Report) {
+	if f.Mode != nil {
+		r.AddOnWarn(c.Append("mode"), baseutil.CheckForDecimalMode(*f.Mode, false))
 	}
 	return
 }

--- a/base/v0_4_exp/validate_test.go
+++ b/base/v0_4_exp/validate_test.go
@@ -152,3 +152,63 @@ func TestValidateTree(t *testing.T) {
 		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
+
+func TestValidateMode(t *testing.T) {
+	fileTests := []struct {
+		in  File
+		out error
+	}{
+		{
+			in:  File{},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(0600),
+			},
+			out: nil,
+		},
+		{
+			in: File{
+				Mode: util.IntToPtr(600),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range fileTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+
+	dirTests := []struct {
+		in  Directory
+		out error
+	}{
+		{
+			in:  Directory{},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(01770),
+			},
+			out: nil,
+		},
+		{
+			in: Directory{
+				Mode: util.IntToPtr(1770),
+			},
+			out: common.ErrDecimalMode,
+		},
+	}
+
+	for i, test := range dirTests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnWarn(path.New("yaml", "mode"), test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+}

--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -36,6 +36,9 @@ var (
 	ErrTreeNotDirectory       = errors.New("root of tree must be a directory")
 	ErrTreeNoLocal            = errors.New("local is required")
 
+	// filesystem nodes
+	ErrDecimalMode = errors.New("unreasonable mode would be reasonable if specified in octal; remember to add a leading zero")
+
 	// mount units
 	ErrMountUnitNoPath   = errors.New("path is required if with_mount_unit is true")
 	ErrMountUnitNoFormat = errors.New("format is required if with_mount_unit is true")


### PR DESCRIPTION
Users sometimes forget to write file/directory modes with a leading zero and end up with a nonsensical configuration.  If a specified mode is unreasonable but would have been reasonable if it had been written in octal, report a warning.  Apply to all spec versions because it's just a warning.

Closes #131.