### PR TITLE
base/*: consistently use testify

### DIFF
--- a/base/util/test.go
+++ b/base/util/test.go
@@ -15,12 +15,9 @@
 package util
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/coreos/fcct/translate"
-
-	"github.com/clarketm/json"
 )
 
 // helper functions for writing tests
@@ -54,14 +51,4 @@ func VerifyTranslations(set translate.TranslationSet, exceptions ...translate.Tr
 		}
 	}
 	return nil
-}
-
-/// FormatJSON serializes the input to formatted JSON for display when a
-/// test fails
-func FormatJSON(from interface{}) string {
-	buf, err := json.MarshalIndent(from, "", "  ")
-	if err != nil {
-		return fmt.Sprintf("<Error marshaling to JSON: %v>", err)
-	}
-	return string(buf)
 }

--- a/base/v0_1/translate_test.go
+++ b/base/v0_1/translate_test.go
@@ -15,7 +15,6 @@
 package v0_1
 
 import (
-	"reflect"
 	"testing"
 
 	baseutil "github.com/coreos/fcct/base/util"
@@ -25,6 +24,8 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_0/types"
 	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
@@ -130,19 +131,10 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, report := translateFile(test.in, common.TranslateOptions{})
-
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
-		}
-
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
-
-		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
-			t.Errorf("#%d: bad translation: %v", i, *errT)
-		}
+		actual, translations, r := translateFile(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		assert.Equal(t, ((*translate.Translation)(nil)), baseutil.VerifyTranslations(translations, test.exceptions...), "#%d: bad translation", i)
 	}
 }
 
@@ -193,13 +185,9 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateDirectory(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateDirectory(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -252,13 +240,9 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateLink(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateLink(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -277,13 +261,9 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := translateIgnition(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateIgnition(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -304,12 +284,8 @@ func TestToIgn3_0(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %+v got %+v", i, test.out, actual)
-		}
+		actual, _, r := test.in.ToIgn3_0Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }

--- a/base/v0_1/validate_test.go
+++ b/base/v0_1/validate_test.go
@@ -15,7 +15,6 @@
 package v0_1
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/coreos/fcct/config/common"
@@ -23,6 +22,7 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestValidateFileContents tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
@@ -73,9 +73,6 @@ func TestValidateFileContents(t *testing.T) {
 		// hardcode inline for now since that's the only place errors occur. Move into the
 		// test struct once there's more than one place
 		expected.AddOnError(path.New("yaml", "inline"), test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %+v got %+v", i, expected, actual)
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }

--- a/base/v0_2/translate_test.go
+++ b/base/v0_2/translate_test.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -30,6 +29,8 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_1/types"
 	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
@@ -457,19 +458,10 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, report := translateFile(test.in, test.options)
-
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-
-		if report.String() != test.report {
-			t.Errorf("#%d: expected report '%+v', got '%+v'", i, test.report, report.String())
-		}
-
-		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
-			t.Errorf("#%d: bad translation: %v", i, *errT)
-		}
+		actual, translations, r := translateFile(test.in, test.options)
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
+		assert.Equal(t, ((*translate.Translation)(nil)), baseutil.VerifyTranslations(translations, test.exceptions...), "#%d: bad translation", i)
 	}
 }
 
@@ -520,13 +512,9 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateDirectory(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateDirectory(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -579,13 +567,9 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateLink(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateLink(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -635,13 +619,9 @@ func TestTranslateFilesystem(t *testing.T) {
 			},
 		}
 		expected := []types.Filesystem{test.out}
-		actual, _, report := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-		if !reflect.DeepEqual(actual.Storage.Filesystems, expected) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual.Storage.Filesystems))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -1080,27 +1060,17 @@ func TestTranslateTree(t *testing.T) {
 		if test.options != nil {
 			options = *test.options
 		}
-		actual, _, report := config.ToIgn3_1Unvalidated(options)
+		actual, _, r := config.ToIgn3_1Unvalidated(options)
 
 		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		if report.String() != expectedReport {
-			t.Errorf("#%d: expected report '%+v', got '%+v'", i, expectedReport, report.String())
-		}
+		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
 		if expectedReport != "" {
 			continue
 		}
 
-		if !reflect.DeepEqual(actual.Storage.Files, test.outFiles) {
-			t.Errorf("#%d: expected files %v, got %v", i, baseutil.FormatJSON(test.outFiles), baseutil.FormatJSON(actual.Storage.Files))
-		}
-
-		if len(actual.Storage.Directories) != 0 {
-			t.Errorf("#%d: expected empty directories, got %v", i, baseutil.FormatJSON(actual.Storage.Directories))
-		}
-
-		if !reflect.DeepEqual(actual.Storage.Links, test.outLinks) {
-			t.Errorf("#%d: expected links %v, got %v", i, baseutil.FormatJSON(test.outLinks), baseutil.FormatJSON(actual.Storage.Links))
-		}
+		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
+		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
+		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
 	}
 }
 
@@ -1186,13 +1156,9 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := translateIgnition(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateIgnition(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -1213,12 +1179,8 @@ func TestToIgn3_1(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
+		actual, _, r := test.in.ToIgn3_1Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }

--- a/base/v0_2/validate_test.go
+++ b/base/v0_2/validate_test.go
@@ -15,15 +15,14 @@
 package v0_2
 
 import (
-	"reflect"
 	"testing"
 
-	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestValidateResource tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
@@ -131,10 +130,7 @@ func TestValidateResource(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(test.errPath, test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
 
@@ -153,9 +149,6 @@ func TestValidateTree(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(path.New("yaml"), test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }

--- a/base/v0_3/validate_test.go
+++ b/base/v0_3/validate_test.go
@@ -15,15 +15,14 @@
 package v0_3
 
 import (
-	"reflect"
 	"testing"
 
-	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestValidateResource tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
@@ -131,10 +130,7 @@ func TestValidateResource(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(test.errPath, test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
 
@@ -153,9 +149,6 @@ func TestValidateTree(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(path.New("yaml"), test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }

--- a/base/v0_4_exp/translate_test.go
+++ b/base/v0_4_exp/translate_test.go
@@ -19,7 +19,6 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"reflect"
 	"strings"
 	"testing"
 
@@ -30,6 +29,8 @@ import (
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
 	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // Most of this is covered by the Ignition translator generic tests, so just test the custom bits
@@ -457,19 +458,10 @@ func TestTranslateFile(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, translations, report := translateFile(test.in, test.options)
-
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-
-		if report.String() != test.report {
-			t.Errorf("#%d: expected report '%+v', got '%+v'", i, test.report, report.String())
-		}
-
-		if errT := baseutil.VerifyTranslations(translations, test.exceptions...); errT != nil {
-			t.Errorf("#%d: bad translation: %v", i, *errT)
-		}
+		actual, translations, r := translateFile(test.in, test.options)
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, test.report, r.String(), "#%d: bad report", i)
+		assert.Equal(t, ((*translate.Translation)(nil)), baseutil.VerifyTranslations(translations, test.exceptions...), "#%d: bad translation", i)
 	}
 }
 
@@ -520,13 +512,9 @@ func TestTranslateDirectory(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateDirectory(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateDirectory(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -579,13 +567,9 @@ func TestTranslateLink(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		actual, _, report := translateLink(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateLink(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -635,13 +619,9 @@ func TestTranslateFilesystem(t *testing.T) {
 			},
 		}
 		expected := []types.Filesystem{test.out}
-		actual, _, report := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		if !reflect.DeepEqual(actual.Storage.Filesystems, expected) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual.Storage.Filesystems))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, expected, actual.Storage.Filesystems, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -1080,27 +1060,17 @@ func TestTranslateTree(t *testing.T) {
 		if test.options != nil {
 			options = *test.options
 		}
-		actual, _, report := config.ToIgn3_3Unvalidated(options)
+		actual, _, r := config.ToIgn3_3Unvalidated(options)
 
 		expectedReport := strings.ReplaceAll(test.report, "%FilesDir%", filesDir)
-		if report.String() != expectedReport {
-			t.Errorf("#%d: expected report '%+v', got '%+v'", i, expectedReport, report.String())
-		}
+		assert.Equal(t, expectedReport, r.String(), "#%d: bad report", i)
 		if expectedReport != "" {
 			continue
 		}
 
-		if !reflect.DeepEqual(actual.Storage.Files, test.outFiles) {
-			t.Errorf("#%d: expected files %v, got %v", i, baseutil.FormatJSON(test.outFiles), baseutil.FormatJSON(actual.Storage.Files))
-		}
-
-		if len(actual.Storage.Directories) != 0 {
-			t.Errorf("#%d: expected empty directories, got %v", i, baseutil.FormatJSON(actual.Storage.Directories))
-		}
-
-		if !reflect.DeepEqual(actual.Storage.Links, test.outLinks) {
-			t.Errorf("#%d: expected links %v, got %v", i, baseutil.FormatJSON(test.outLinks), baseutil.FormatJSON(actual.Storage.Links))
-		}
+		assert.Equal(t, test.outFiles, actual.Storage.Files, "#%d: files mismatch", i)
+		assert.Equal(t, []types.Directory(nil), actual.Storage.Directories, "#%d: directories mismatch", i)
+		assert.Equal(t, test.outLinks, actual.Storage.Links, "#%d: links mismatch", i)
 	}
 }
 
@@ -1186,13 +1156,9 @@ func TestTranslateIgnition(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := translateIgnition(test.in, common.TranslateOptions{})
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
+		actual, _, r := translateIgnition(test.in, common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }
 
@@ -1213,12 +1179,8 @@ func TestToIgn3_3(t *testing.T) {
 		},
 	}
 	for i, test := range tests {
-		actual, _, report := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
-		if report.String() != "" {
-			t.Errorf("#%d: got non-empty report: %v", i, report.String())
-		}
-		if !reflect.DeepEqual(actual, test.out) {
-			t.Errorf("#%d: expected %v, got %v", i, baseutil.FormatJSON(test.out), baseutil.FormatJSON(actual))
-		}
+		actual, _, r := test.in.ToIgn3_3Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
 	}
 }

--- a/base/v0_4_exp/validate_test.go
+++ b/base/v0_4_exp/validate_test.go
@@ -15,15 +15,14 @@
 package v0_4_exp
 
 import (
-	"reflect"
 	"testing"
 
-	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 // TestValidateResource tests that multiple sources (i.e. urls and inline) are not allowed but zero or one sources are
@@ -131,10 +130,7 @@ func TestValidateResource(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(test.errPath, test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }
 
@@ -153,9 +149,6 @@ func TestValidateTree(t *testing.T) {
 		actual := test.in.Validate(path.New("yaml"))
 		expected := report.Report{}
 		expected.AddOnError(path.New("yaml"), test.out)
-
-		if !reflect.DeepEqual(actual, expected) {
-			t.Errorf("#%d: expected %v got %v", i, baseutil.FormatJSON(expected), baseutil.FormatJSON(actual))
-		}
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
 	}
 }


### PR DESCRIPTION
It's easier when writing tests and produces nicer output.