### PR TITLE
Add boot_device sugar

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -42,4 +42,8 @@ var (
 	// mount units
 	ErrMountUnitNoPath   = errors.New("path is required if with_mount_unit is true")
 	ErrMountUnitNoFormat = errors.New("format is required if with_mount_unit is true")
+
+	// boot device
+	ErrUnknownBootDeviceLayout = errors.New("layout must be one of: aarch64, ppc64le, x86_64")
+	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -42,7 +42,7 @@ func init() {
 	RegisterTranslator("fcos", "1.0.0", fcos1_0.ToIgn3_0Bytes)
 	RegisterTranslator("fcos", "1.1.0", fcos1_1.ToIgn3_1Bytes)
 	RegisterTranslator("fcos", "1.2.0", fcos1_2.ToIgn3_2Bytes)
-	RegisterTranslator("fcos", "1.3.0-experimental", fcos1_3_exp.ToIgn3_3Bytes)
+	RegisterTranslator("fcos", "1.3.0-experimental", fcos1_3_exp.ToIgn3_2Bytes)
 }
 
 /// RegisterTranslator registers a translator for the specified variant and

--- a/config/fcos/v1_3_exp/schema.go
+++ b/config/fcos/v1_3_exp/schema.go
@@ -15,7 +15,7 @@
 package v1_3_exp
 
 import (
-	base "github.com/coreos/fcct/base/v0_4_exp"
+	base "github.com/coreos/fcct/base/v0_3"
 )
 
 type Config struct {

--- a/config/fcos/v1_3_exp/translate.go
+++ b/config/fcos/v1_3_exp/translate.go
@@ -15,12 +15,57 @@
 package v1_3_exp
 
 import (
+	"fmt"
+
+	baseutil "github.com/coreos/fcct/base/util"
 	"github.com/coreos/fcct/config/common"
 	cutil "github.com/coreos/fcct/config/util"
+	"github.com/coreos/fcct/translate"
 
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
+
+const (
+	biosTypeGuid = "21686148-6449-6E6F-744E-656564454649"
+	prepTypeGuid = "9E1A2D38-C612-4316-AA26-8B49521E5A8B"
+	espTypeGuid  = "C12A7328-F81F-11D2-BA4B-00A0C93EC93B"
+
+	// The partition layout implemented in this file replicates
+	// the layout of the OS image defined in:
+	// https://github.com/coreos/coreos-assembler/blob/master/src/create_disk.sh
+	//
+	// Exception: we don't try to skip unused partition numbers,
+	// because specifying a partition number would prevent child
+	// configs from overriding partition fields using the partition
+	// label as the lookup key.
+	//
+	// It's not critical that we match that layout exactly; the hard
+	// constraints are:
+	//   - The desugared partition cannot be smaller than the one it
+	//     replicates
+	//   - The new BIOS-BOOT partition (and maybe the PReP one?) must be
+	//     at the same offset as the original
+	//
+	// Do not change these constants!  New partition layouts must be
+	// encoded into new layout templates.
+	biosV1SizeMiB = 1
+	prepV1SizeMiB = 4
+	espV1SizeMiB  = 127
+	bootV1SizeMiB = 384
+)
+
+// ToIgn3_2Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	ret, ts, r := c.Config.ToIgn3_2Unvalidated(options)
+	r.Merge(c.processBootDevice(&ret, &ts, options))
+	return ret, ts, r
+}
 
 // ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
@@ -36,4 +81,174 @@ func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.
 // translating, an error is returned.
 func ToIgn3_2Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
 	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
+}
+
+func (c Config) processBootDevice(config *types.Config, ts *translate.TranslationSet, options common.TranslateOptions) report.Report {
+	var rendered types.Config
+	renderedTranslations := translate.NewTranslationSet("yaml", "json")
+	var r report.Report
+
+	// check for high-level features
+	wantLuks := (c.BootDevice.Luks.Tpm2 != nil && *c.BootDevice.Luks.Tpm2) || len(c.BootDevice.Luks.Tang) > 0
+	wantMirror := len(c.BootDevice.Mirror.Devices) > 0
+	if !wantLuks && !wantMirror {
+		return r
+	}
+
+	// compute layout rendering options
+	var wantBIOSPart bool
+	var wantPRePPart bool
+	layout := c.BootDevice.Layout
+	switch {
+	case layout == nil || *layout == "x86_64":
+		wantBIOSPart = true
+	case *layout == "aarch64":
+		// neither BIOS or PReP
+	case *layout == "ppc64le":
+		wantPRePPart = true
+	default:
+		// should have failed validation
+		panic("unknown layout")
+	}
+
+	// mirrored root disk
+	if wantMirror {
+		// partition disks
+		for i, device := range c.BootDevice.Mirror.Devices {
+			labelIndex := len(rendered.Storage.Disks) + 1
+			disk := types.Disk{
+				Device:    device,
+				WipeTable: util.BoolToPtr(true),
+			}
+			if wantBIOSPart {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("bios-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+					TypeGUID: util.StrToPtr(biosTypeGuid),
+				})
+			}
+			if wantPRePPart {
+				disk.Partitions = append(disk.Partitions, types.Partition{
+					Label:    util.StrToPtr(fmt.Sprintf("prep-%d", labelIndex)),
+					SizeMiB:  util.IntToPtr(prepV1SizeMiB),
+					TypeGUID: util.StrToPtr(prepTypeGuid),
+				})
+			}
+			disk.Partitions = append(disk.Partitions, types.Partition{
+				Label:    util.StrToPtr(fmt.Sprintf("esp-%d", labelIndex)),
+				SizeMiB:  util.IntToPtr(espV1SizeMiB),
+				TypeGUID: util.StrToPtr(espTypeGuid),
+			}, types.Partition{
+				Label:   util.StrToPtr(fmt.Sprintf("boot-%d", labelIndex)),
+				SizeMiB: util.IntToPtr(bootV1SizeMiB),
+			}, types.Partition{
+				Label: util.StrToPtr(fmt.Sprintf("root-%d", labelIndex)),
+			})
+			renderedTranslations.AddFromCommonSource(path.New("yaml", "boot_device", "mirror", "devices", i), path.New("json", "storage", "disks", len(rendered.Storage.Disks)), disk)
+			rendered.Storage.Disks = append(rendered.Storage.Disks, disk)
+		}
+
+		// create RAIDs
+		raidDevices := func(labelPrefix string) []types.Device {
+			count := len(rendered.Storage.Disks)
+			ret := make([]types.Device, count)
+			for i := 0; i < count; i++ {
+				ret[i] = types.Device(fmt.Sprintf("/dev/disk/by-partlabel/%s-%d", labelPrefix, i+1))
+			}
+			return ret
+		}
+		rendered.Storage.Raid = []types.Raid{{
+			Devices: raidDevices("esp"),
+			Level:   "raid1",
+			Name:    "md-esp",
+			// put the RAID superblock at the end of the
+			// partition to avoid confusing UEFI
+			Options: []types.RaidOption{"--metadata=1.0"},
+		}, {
+			Devices: raidDevices("boot"),
+			Level:   "raid1",
+			Name:    "md-boot",
+			// put the RAID superblock at the end of the
+			// partition so BIOS GRUB doesn't need to
+			// understand RAID
+			Options: []types.RaidOption{"--metadata=1.0"},
+		}, {
+			Devices: raidDevices("root"),
+			Level:   "raid1",
+			Name:    "md-root",
+		}}
+		renderedTranslations.AddFromCommonSource(path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid"), rendered.Storage.Raid)
+
+		// create filesystems, except for root
+		rendered.Storage.Filesystems = []types.Filesystem{{
+			Device:         "/dev/md/md-esp",
+			Format:         util.StrToPtr("vfat"),
+			Label:          util.StrToPtr("EFI-SYSTEM"),
+			WipeFilesystem: util.BoolToPtr(true),
+		}, {
+			Device:         "/dev/md/md-boot",
+			Format:         util.StrToPtr("ext4"),
+			Label:          util.StrToPtr("boot"),
+			WipeFilesystem: util.BoolToPtr(true),
+		}}
+		renderedTranslations.AddFromCommonSource(path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems"), rendered.Storage.Filesystems)
+	}
+
+	// encrypted root partition
+	if wantLuks {
+		luksDevice := "/dev/disk/by-partlabel/root"
+		if wantMirror {
+			luksDevice = "/dev/md/md-root"
+		}
+		clevis, ts2, r2 := translateBootDeviceLuks(c.BootDevice.Luks, options)
+		rendered.Storage.Luks = []types.Luks{{
+			Clevis:     &clevis,
+			Device:     &luksDevice,
+			Label:      util.StrToPtr("luks-root"),
+			Name:       "root",
+			WipeVolume: util.BoolToPtr(true),
+		}}
+		lpath := path.New("yaml", "boot_device", "luks")
+		rpath := path.New("json", "storage", "luks", 0)
+		renderedTranslations.Merge(ts2.PrefixPaths(lpath, rpath.Append("clevis")))
+		for _, f := range []string{"device", "label", "name", "wipeVolume"} {
+			renderedTranslations.AddTranslation(lpath, rpath.Append(f))
+		}
+		r.Merge(r2)
+	}
+
+	// create root filesystem
+	var rootDevice string
+	switch {
+	case wantLuks:
+		// LUKS, or LUKS on RAID
+		rootDevice = "/dev/mapper/root"
+	case wantMirror:
+		// RAID without LUKS
+		rootDevice = "/dev/md/md-root"
+	default:
+		panic("can't happen")
+	}
+	rootFilesystem := types.Filesystem{
+		Device:         rootDevice,
+		Format:         util.StrToPtr("xfs"),
+		Label:          util.StrToPtr("root"),
+		WipeFilesystem: util.BoolToPtr(true),
+	}
+	renderedTranslations.AddFromCommonSource(path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", len(rendered.Storage.Filesystems)), rootFilesystem)
+	rendered.Storage.Filesystems = append(rendered.Storage.Filesystems, rootFilesystem)
+
+	// merge with translated config
+	retConfig, retTranslations := baseutil.MergeTranslatedConfigs(rendered, renderedTranslations, *config, *ts)
+	*config = retConfig.(types.Config)
+	*ts = retTranslations
+	return r
+}
+
+func translateBootDeviceLuks(from BootDeviceLuks, options common.TranslateOptions) (to types.Clevis, tm translate.TranslationSet, r report.Report) {
+	tr := translate.NewTranslator("yaml", "json", options)
+	tm, r = translate.Prefixed(tr, "tang", &from.Tang, &to.Tang)
+	translate.MergeP(tr, tm, &r, "threshold", &from.Threshold, &to.Threshold)
+	translate.MergeP(tr, tm, &r, "tpm2", &from.Tpm2, &to.Tpm2)
+	return
 }

--- a/config/fcos/v1_3_exp/translate.go
+++ b/config/fcos/v1_3_exp/translate.go
@@ -18,22 +18,22 @@ import (
 	"github.com/coreos/fcct/config/common"
 	cutil "github.com/coreos/fcct/config/util"
 
-	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/report"
 )
 
-// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
 // the report has fatal errors or it encounters other problems translating,
 // an error is returned.
-func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
-	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
 	return cfg.(types.Config), r, err
 }
 
-// ToIgn3_3Bytes translates from a v1.3 fcc to a v3.3.0 Ignition config. It returns a report of any errors or
+// ToIgn3_2Bytes translates from a v1.3 fcc to a v3.2.0 Ignition config. It returns a report of any errors or
 // warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
 // translating, an error is returned.
-func ToIgn3_3Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
-	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+func ToIgn3_2Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
 }

--- a/config/fcos/v1_3_exp/translate_test.go
+++ b/config/fcos/v1_3_exp/translate_test.go
@@ -1,0 +1,1159 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_3_exp
+
+import (
+	"testing"
+
+	baseutil "github.com/coreos/fcct/base/util"
+	base "github.com/coreos/fcct/base/v0_3"
+	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/translate"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// Most of this is covered by the Ignition translator generic tests, so just test the custom bits
+
+// TestTranslateBootDevice tests translating the FCC boot_device section.
+func TestTranslateBootDevice(t *testing.T) {
+	tests := []struct {
+		in         Config
+		out        types.Config
+		exceptions []translate.Translation
+	}{
+		// empty config
+		{
+			Config{},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+			},
+			[]translate.Translation{},
+		},
+		// LUKS, x86_64
+		{
+			Config{
+				BootDevice: BootDevice{
+					Luks: BootDeviceLuks{
+						Tang: []base.Tang{{
+							URL:        "https://example.com/",
+							Thumbprint: util.StrToPtr("z"),
+						}},
+						Threshold: util.IntToPtr(2),
+						Tpm2:      util.BoolToPtr(true),
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Luks: []types.Luks{
+						{
+							Clevis: &types.Clevis{
+								Tang: []types.Tang{{
+									URL:        "https://example.com/",
+									Thumbprint: util.StrToPtr("z"),
+								}},
+								Threshold: util.IntToPtr(2),
+								Tpm2:      util.BoolToPtr(true),
+							},
+							Device:     util.StrToPtr("/dev/disk/by-partlabel/root"),
+							Label:      util.StrToPtr("luks-root"),
+							Name:       "root",
+							WipeVolume: util.BoolToPtr(true),
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/mapper/root",
+							Format:         util.StrToPtr("xfs"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "url"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "url")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "thumbprint"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "thumbprint")},
+				{path.New("yaml", "boot_device", "luks", "threshold"), path.New("json", "storage", "luks", 0, "clevis", "threshold")},
+				{path.New("yaml", "boot_device", "luks", "tpm2"), path.New("json", "storage", "luks", 0, "clevis", "tpm2")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "device")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "label")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "name")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "wipeVolume")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+			},
+		},
+		// 3-disk mirror, x86_64
+		{
+			Config{
+				BootDevice: BootDevice{
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/vda", "/dev/vdb", "/dev/vdc"},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-1"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-1"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-1"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-1"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdb",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-2"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-2"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-2"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-2"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdc",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-3"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-3"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-3"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-3"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+					},
+					Raid: []types.Raid{
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/esp-1",
+								"/dev/disk/by-partlabel/esp-2",
+								"/dev/disk/by-partlabel/esp-3",
+							},
+							Level:   "raid1",
+							Name:    "md-esp",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/boot-1",
+								"/dev/disk/by-partlabel/boot-2",
+								"/dev/disk/by-partlabel/boot-3",
+							},
+							Level:   "raid1",
+							Name:    "md-boot",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/root-1",
+								"/dev/disk/by-partlabel/root-2",
+								"/dev/disk/by-partlabel/root-3",
+							},
+							Level: "raid1",
+							Name:  "md-root",
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/md/md-esp",
+							Format:         util.StrToPtr("vfat"),
+							Label:          util.StrToPtr("EFI-SYSTEM"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-boot",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("boot"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-root",
+							Format:         util.StrToPtr("xfs"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "wipeFilesystem")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "device")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "wipeFilesystem")},
+			},
+		},
+		// 3-disk mirror + LUKS, x86_64
+		{
+			Config{
+				BootDevice: BootDevice{
+					Luks: BootDeviceLuks{
+						Tang: []base.Tang{{
+							URL:        "https://example.com/",
+							Thumbprint: util.StrToPtr("z"),
+						}},
+						Threshold: util.IntToPtr(2),
+						Tpm2:      util.BoolToPtr(true),
+					},
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/vda", "/dev/vdb", "/dev/vdc"},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-1"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-1"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-1"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-1"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdb",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-2"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-2"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-2"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-2"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdc",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-3"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-3"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-3"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-3"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+					},
+					Raid: []types.Raid{
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/esp-1",
+								"/dev/disk/by-partlabel/esp-2",
+								"/dev/disk/by-partlabel/esp-3",
+							},
+							Level:   "raid1",
+							Name:    "md-esp",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/boot-1",
+								"/dev/disk/by-partlabel/boot-2",
+								"/dev/disk/by-partlabel/boot-3",
+							},
+							Level:   "raid1",
+							Name:    "md-boot",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/root-1",
+								"/dev/disk/by-partlabel/root-2",
+								"/dev/disk/by-partlabel/root-3",
+							},
+							Level: "raid1",
+							Name:  "md-root",
+						},
+					},
+					Luks: []types.Luks{
+						{
+							Clevis: &types.Clevis{
+								Tang: []types.Tang{{
+									URL:        "https://example.com/",
+									Thumbprint: util.StrToPtr("z"),
+								}},
+								Threshold: util.IntToPtr(2),
+								Tpm2:      util.BoolToPtr(true),
+							},
+							Device:     util.StrToPtr("/dev/md/md-root"),
+							Label:      util.StrToPtr("luks-root"),
+							Name:       "root",
+							WipeVolume: util.BoolToPtr(true),
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/md/md-esp",
+							Format:         util.StrToPtr("vfat"),
+							Label:          util.StrToPtr("EFI-SYSTEM"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-boot",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("boot"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/mapper/root",
+							Format:         util.StrToPtr("xfs"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 2), path.New("json", "storage", "disks", 2, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 2)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "name")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "url"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "url")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "thumbprint"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "thumbprint")},
+				{path.New("yaml", "boot_device", "luks", "threshold"), path.New("json", "storage", "luks", 0, "clevis", "threshold")},
+				{path.New("yaml", "boot_device", "luks", "tpm2"), path.New("json", "storage", "luks", 0, "clevis", "tpm2")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "device")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "label")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "name")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "wipeVolume")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "wipeFilesystem")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "device")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "wipeFilesystem")},
+			},
+		},
+		// 2-disk mirror + LUKS, aarch64
+		{
+			Config{
+				BootDevice: BootDevice{
+					Layout: util.StrToPtr("aarch64"),
+					Luks: BootDeviceLuks{
+						Tang: []base.Tang{{
+							URL:        "https://example.com/",
+							Thumbprint: util.StrToPtr("z"),
+						}},
+						Threshold: util.IntToPtr(2),
+						Tpm2:      util.BoolToPtr(true),
+					},
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/vda", "/dev/vdb"},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("esp-1"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-1"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-1"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdb",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("esp-2"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-2"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-2"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+					},
+					Raid: []types.Raid{
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/esp-1",
+								"/dev/disk/by-partlabel/esp-2",
+							},
+							Level:   "raid1",
+							Name:    "md-esp",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/boot-1",
+								"/dev/disk/by-partlabel/boot-2",
+							},
+							Level:   "raid1",
+							Name:    "md-boot",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/root-1",
+								"/dev/disk/by-partlabel/root-2",
+							},
+							Level: "raid1",
+							Name:  "md-root",
+						},
+					},
+					Luks: []types.Luks{
+						{
+							Clevis: &types.Clevis{
+								Tang: []types.Tang{{
+									URL:        "https://example.com/",
+									Thumbprint: util.StrToPtr("z"),
+								}},
+								Threshold: util.IntToPtr(2),
+								Tpm2:      util.BoolToPtr(true),
+							},
+							Device:     util.StrToPtr("/dev/md/md-root"),
+							Label:      util.StrToPtr("luks-root"),
+							Name:       "root",
+							WipeVolume: util.BoolToPtr(true),
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/md/md-esp",
+							Format:         util.StrToPtr("vfat"),
+							Label:          util.StrToPtr("EFI-SYSTEM"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-boot",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("boot"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/mapper/root",
+							Format:         util.StrToPtr("xfs"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "name")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "url"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "url")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "thumbprint"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "thumbprint")},
+				{path.New("yaml", "boot_device", "luks", "threshold"), path.New("json", "storage", "luks", 0, "clevis", "threshold")},
+				{path.New("yaml", "boot_device", "luks", "tpm2"), path.New("json", "storage", "luks", 0, "clevis", "tpm2")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "device")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "label")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "name")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "wipeVolume")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "wipeFilesystem")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "device")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "wipeFilesystem")},
+			},
+		},
+		// 2-disk mirror + LUKS, ppc64le
+		{
+			Config{
+				BootDevice: BootDevice{
+					Layout: util.StrToPtr("ppc64le"),
+					Luks: BootDeviceLuks{
+						Tang: []base.Tang{{
+							URL:        "https://example.com/",
+							Thumbprint: util.StrToPtr("z"),
+						}},
+						Threshold: util.IntToPtr(2),
+						Tpm2:      util.BoolToPtr(true),
+					},
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/vda", "/dev/vdb"},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("prep-1"),
+									SizeMiB:  util.IntToPtr(prepV1SizeMiB),
+									TypeGUID: util.StrToPtr(prepTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-1"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-1"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-1"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdb",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("prep-2"),
+									SizeMiB:  util.IntToPtr(prepV1SizeMiB),
+									TypeGUID: util.StrToPtr(prepTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-2"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-2"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label: util.StrToPtr("root-2"),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+					},
+					Raid: []types.Raid{
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/esp-1",
+								"/dev/disk/by-partlabel/esp-2",
+							},
+							Level:   "raid1",
+							Name:    "md-esp",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/boot-1",
+								"/dev/disk/by-partlabel/boot-2",
+							},
+							Level:   "raid1",
+							Name:    "md-boot",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/root-1",
+								"/dev/disk/by-partlabel/root-2",
+							},
+							Level: "raid1",
+							Name:  "md-root",
+						},
+					},
+					Luks: []types.Luks{
+						{
+							Clevis: &types.Clevis{
+								Tang: []types.Tang{{
+									URL:        "https://example.com/",
+									Thumbprint: util.StrToPtr("z"),
+								}},
+								Threshold: util.IntToPtr(2),
+								Tpm2:      util.BoolToPtr(true),
+							},
+							Device:     util.StrToPtr("/dev/md/md-root"),
+							Label:      util.StrToPtr("luks-root"),
+							Name:       "root",
+							WipeVolume: util.BoolToPtr(true),
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/md/md-esp",
+							Format:         util.StrToPtr("vfat"),
+							Label:          util.StrToPtr("EFI-SYSTEM"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-boot",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("boot"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/mapper/root",
+							Format:         util.StrToPtr("xfs"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "name")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "url"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "url")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "thumbprint"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "thumbprint")},
+				{path.New("yaml", "boot_device", "luks", "threshold"), path.New("json", "storage", "luks", 0, "clevis", "threshold")},
+				{path.New("yaml", "boot_device", "luks", "tpm2"), path.New("json", "storage", "luks", 0, "clevis", "tpm2")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "device")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "label")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "name")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "wipeVolume")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "wipeFilesystem")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "device")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "wipeFilesystem")},
+			},
+		},
+		// 2-disk mirror + LUKS with overridden root partition size
+		// and filesystem type, x86_64
+		{
+			Config{
+				Config: base.Config{
+					Storage: base.Storage{
+						Disks: []base.Disk{
+							{
+								Device: "/dev/vda",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root-1"),
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+							{
+								Device: "/dev/vdb",
+								Partitions: []base.Partition{
+									{
+										Label:   util.StrToPtr("root-2"),
+										SizeMiB: util.IntToPtr(8192),
+									},
+								},
+							},
+						},
+						Filesystems: []base.Filesystem{
+							{
+								Device: "/dev/mapper/root",
+								Format: util.StrToPtr("ext4"),
+							},
+						},
+					},
+				},
+				BootDevice: BootDevice{
+					Luks: BootDeviceLuks{
+						Tang: []base.Tang{{
+							URL:        "https://example.com/",
+							Thumbprint: util.StrToPtr("z"),
+						}},
+						Threshold: util.IntToPtr(2),
+						Tpm2:      util.BoolToPtr(true),
+					},
+					Mirror: BootDeviceMirror{
+						Devices: []string{"/dev/vda", "/dev/vdb"},
+					},
+				},
+			},
+			types.Config{
+				Ignition: types.Ignition{
+					Version: "3.2.0",
+				},
+				Storage: types.Storage{
+					Disks: []types.Disk{
+						{
+							Device: "/dev/vda",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-1"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-1"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-1"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label:   util.StrToPtr("root-1"),
+									SizeMiB: util.IntToPtr(8192),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+						{
+							Device: "/dev/vdb",
+							Partitions: []types.Partition{
+								{
+									Label:    util.StrToPtr("bios-2"),
+									SizeMiB:  util.IntToPtr(biosV1SizeMiB),
+									TypeGUID: util.StrToPtr(biosTypeGuid),
+								},
+								{
+									Label:    util.StrToPtr("esp-2"),
+									SizeMiB:  util.IntToPtr(espV1SizeMiB),
+									TypeGUID: util.StrToPtr(espTypeGuid),
+								},
+								{
+									Label:   util.StrToPtr("boot-2"),
+									SizeMiB: util.IntToPtr(bootV1SizeMiB),
+								},
+								{
+									Label:   util.StrToPtr("root-2"),
+									SizeMiB: util.IntToPtr(8192),
+								},
+							},
+							WipeTable: util.BoolToPtr(true),
+						},
+					},
+					Raid: []types.Raid{
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/esp-1",
+								"/dev/disk/by-partlabel/esp-2",
+							},
+							Level:   "raid1",
+							Name:    "md-esp",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/boot-1",
+								"/dev/disk/by-partlabel/boot-2",
+							},
+							Level:   "raid1",
+							Name:    "md-boot",
+							Options: []types.RaidOption{"--metadata=1.0"},
+						},
+						{
+							Devices: []types.Device{
+								"/dev/disk/by-partlabel/root-1",
+								"/dev/disk/by-partlabel/root-2",
+							},
+							Level: "raid1",
+							Name:  "md-root",
+						},
+					},
+					Luks: []types.Luks{
+						{
+							Clevis: &types.Clevis{
+								Tang: []types.Tang{{
+									URL:        "https://example.com/",
+									Thumbprint: util.StrToPtr("z"),
+								}},
+								Threshold: util.IntToPtr(2),
+								Tpm2:      util.BoolToPtr(true),
+							},
+							Device:     util.StrToPtr("/dev/md/md-root"),
+							Label:      util.StrToPtr("luks-root"),
+							Name:       "root",
+							WipeVolume: util.BoolToPtr(true),
+						},
+					},
+					Filesystems: []types.Filesystem{
+						{
+							Device:         "/dev/md/md-esp",
+							Format:         util.StrToPtr("vfat"),
+							Label:          util.StrToPtr("EFI-SYSTEM"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/md/md-boot",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("boot"),
+							WipeFilesystem: util.BoolToPtr(true),
+						}, {
+							Device:         "/dev/mapper/root",
+							Format:         util.StrToPtr("ext4"),
+							Label:          util.StrToPtr("root"),
+							WipeFilesystem: util.BoolToPtr(true),
+						},
+					},
+				},
+			},
+			[]translate.Translation{
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "label"), path.New("json", "storage", "disks", 0, "partitions", 3, "label")},
+				{path.New("yaml", "storage", "disks", 0, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 0, "partitions", 3, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 0), path.New("json", "storage", "disks", 0, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 0, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 1, "typeGuid")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "label")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "partitions", 2, "sizeMiB")},
+				{path.New("yaml", "storage", "disks", 1, "partitions", 0, "label"), path.New("json", "storage", "disks", 1, "partitions", 3, "label")},
+				{path.New("yaml", "storage", "disks", 1, "partitions", 0, "size_mib"), path.New("json", "storage", "disks", 1, "partitions", 3, "sizeMiB")},
+				{path.New("yaml", "boot_device", "mirror", "devices", 1), path.New("json", "storage", "disks", 1, "wipeTable")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 0, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "name")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 1, "options", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 0)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "devices", 1)},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "level")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "raid", 2, "name")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "url"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "url")},
+				{path.New("yaml", "boot_device", "luks", "tang", 0, "thumbprint"), path.New("json", "storage", "luks", 0, "clevis", "tang", 0, "thumbprint")},
+				{path.New("yaml", "boot_device", "luks", "threshold"), path.New("json", "storage", "luks", 0, "clevis", "threshold")},
+				{path.New("yaml", "boot_device", "luks", "tpm2"), path.New("json", "storage", "luks", 0, "clevis", "tpm2")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "device")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "label")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "name")},
+				{path.New("yaml", "boot_device", "luks"), path.New("json", "storage", "luks", 0, "wipeVolume")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 0, "wipeFilesystem")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "device")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "format")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "label")},
+				{path.New("yaml", "boot_device", "mirror"), path.New("json", "storage", "filesystems", 1, "wipeFilesystem")},
+				{path.New("yaml", "storage", "filesystems", 0, "device"), path.New("json", "storage", "filesystems", 2, "device")},
+				{path.New("yaml", "storage", "filesystems", 0, "format"), path.New("json", "storage", "filesystems", 2, "format")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "label")},
+				{path.New("yaml", "boot_device"), path.New("json", "storage", "filesystems", 2, "wipeFilesystem")},
+			},
+		},
+	}
+
+	// The partition sizes of existing layouts must never change, but
+	// we use the constants in tests for clarity.  Ensure no one has
+	// changed them.
+	assert.Equal(t, biosV1SizeMiB, 1)
+	assert.Equal(t, prepV1SizeMiB, 4)
+	assert.Equal(t, espV1SizeMiB, 127)
+	assert.Equal(t, bootV1SizeMiB, 384)
+
+	for i, test := range tests {
+		actual, translations, r := test.in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+		assert.Equal(t, test.out, actual, "#%d: translation mismatch", i)
+		assert.Equal(t, report.Report{}, r, "#%d: non-empty report", i)
+		baseutil.VerifyTranslations(t, translations, test.exceptions, "#%d", i)
+	}
+}

--- a/config/fcos/v1_3_exp/validate_test.go
+++ b/config/fcos/v1_3_exp/validate_test.go
@@ -1,0 +1,87 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v1_3_exp
+
+import (
+	"testing"
+
+	base "github.com/coreos/fcct/base/v0_3"
+	"github.com/coreos/fcct/config/common"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestValidateBootDevice tests boot device validation
+func TestValidateBootDevice(t *testing.T) {
+	tests := []struct {
+		in      BootDevice
+		out     error
+		errPath path.ContextPath
+	}{
+		// empty config
+		{
+			BootDevice{},
+			nil,
+			path.New("yaml"),
+		},
+		// complete config
+		{
+			BootDevice{
+				Layout: util.StrToPtr("x86_64"),
+				Luks: BootDeviceLuks{
+					Tang: []base.Tang{{
+						URL:        "https://example.com/",
+						Thumbprint: util.StrToPtr("x"),
+					}},
+					Threshold: util.IntToPtr(2),
+					Tpm2:      util.BoolToPtr(true),
+				},
+				Mirror: BootDeviceMirror{
+					Devices: []string{"/dev/vda", "/dev/vdb"},
+				},
+			},
+			nil,
+			path.New("yaml"),
+		},
+		// invalid layout
+		{
+			BootDevice{
+				Layout: util.StrToPtr("sparc"),
+			},
+			common.ErrUnknownBootDeviceLayout,
+			path.New("yaml", "layout"),
+		},
+		// only one mirror device
+		{
+			BootDevice{
+				Mirror: BootDeviceMirror{
+					Devices: []string{"/dev/vda"},
+				},
+			},
+			common.ErrTooFewMirrorDevices,
+			path.New("yaml", "mirror", "devices"),
+		},
+	}
+
+	for i, test := range tests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnError(test.errPath, test.out)
+		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
+	}
+}

--- a/docs/configuration-v1_3-exp.md
+++ b/docs/configuration-v1_3-exp.md
@@ -190,6 +190,16 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_gid_** (integer): the group ID of the new group.
     * **_password_hash_** (string): the hashed password of the new group.
     * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+      * **url** (string): url of the tang server.
+      * **thumbprint** (string): thumbprint of a trusted signing key.
+    * **_tpm2_** (bool): whether or not to use a tpm2 device.
+    * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+  * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
+    * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/docs/configuration-v1_3-exp.md
+++ b/docs/configuration-v1_3-exp.md
@@ -12,7 +12,7 @@ nav_order: 4
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
-* **version** (string): the semantic version of the spec for this document. This document is for version `1.3.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.3.0-experimental` and generates Ignition configs with version `3.2.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -42,4 +42,4 @@ specification:
 | 1.0.0              | 3.0.0              |
 | 1.1.0              | 3.1.0              |
 | 1.2.0              | 3.2.0              |
-| 1.3.0-experimental | 3.3.0-experimental |
+| 1.3.0-experimental | 3.2.0              |

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
-	github.com/coreos/ignition/v2 v2.7.1-0.20201124074945-129ef9cd9b40
+	github.com/coreos/ignition/v2 v2.8.1
 	github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/ignition/v2 v2.7.1-0.20201124074945-129ef9cd9b40 h1:L2od4wU+41Zk3nXrOlz+JRkYOMsZisHLBtZR+qH1LHk=
-github.com/coreos/ignition/v2 v2.7.1-0.20201124074945-129ef9cd9b40/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
+github.com/coreos/ignition/v2 v2.8.1 h1:gKCX6NwGGFh866MvpJlq2ZCqppVbWK0DA/uflL34tDU=
+github.com/coreos/ignition/v2 v2.8.1/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/coreos/go-semver/semver
 github.com/coreos/go-systemd/unit
 # github.com/coreos/go-systemd/v22 v22.0.0
 github.com/coreos/go-systemd/v22/unit
-# github.com/coreos/ignition/v2 v2.7.1-0.20201124074945-129ef9cd9b40
+# github.com/coreos/ignition/v2 v2.8.1
 github.com/coreos/ignition/v2/config/merge
 github.com/coreos/ignition/v2/config/shared/errors
 github.com/coreos/ignition/v2/config/shared/validations


### PR DESCRIPTION
Add sugar for mirroring the root disk (all partitions) and/or encrypting the root partition.  Design document in https://github.com/coreos/enhancements/pull/3.

Example FCC:

```yaml
variant: fcos
version: 1.3.0-experimental
boot_device:
  # Specifies a disk layout template.  Supported values are aarch64,
  # ppc64le, x86_64 (default).
  layout: x86_64
  mirror:
    # If specified, mirror every default partition.  Two or more devices
    # are required.
    devices:
      - /dev/vda
      - /dev/vdb
  luks:
    # If tang and/or tpm2 is specified, encrypt the root partition.
    tang:
      - url: https://example.com/
        thumbprint: x
    tpm2: true
    threshold: 2
```