### PR TITLE
config: add rhcos 0.1.0 and 0.2.0-experimental variants

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ import (
 	fcos1_3 "github.com/coreos/fcct/config/fcos/v1_3"
 	fcos1_4_exp "github.com/coreos/fcct/config/fcos/v1_4_exp"
 	rhcos0_1 "github.com/coreos/fcct/config/rhcos/v0_1"
+	rhcos0_2_exp "github.com/coreos/fcct/config/rhcos/v0_2_exp"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/vcontext/report"
@@ -47,6 +48,7 @@ func init() {
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0-experimental", fcos1_4_exp.ToIgn3_3Bytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
+	RegisterTranslator("rhcos", "0.2.0-experimental", rhcos0_2_exp.ToIgn3_3Bytes)
 }
 
 /// RegisterTranslator registers a translator for the specified variant and

--- a/config/config.go
+++ b/config/config.go
@@ -23,6 +23,7 @@ import (
 	fcos1_2 "github.com/coreos/fcct/config/fcos/v1_2"
 	fcos1_3 "github.com/coreos/fcct/config/fcos/v1_3"
 	fcos1_4_exp "github.com/coreos/fcct/config/fcos/v1_4_exp"
+	rhcos0_1 "github.com/coreos/fcct/config/rhcos/v0_1"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/vcontext/report"
@@ -45,6 +46,7 @@ func init() {
 	RegisterTranslator("fcos", "1.2.0", fcos1_2.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0-experimental", fcos1_4_exp.ToIgn3_3Bytes)
+	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
 }
 
 /// RegisterTranslator registers a translator for the specified variant and

--- a/config/rhcos/v0_1/schema.go
+++ b/config/rhcos/v0_1/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_1
+
+import (
+	fcos "github.com/coreos/fcct/config/fcos/v1_3"
+)
+
+type Config struct {
+	fcos.Config `yaml:",inline"`
+}

--- a/config/rhcos/v0_1/translate.go
+++ b/config/rhcos/v0_1/translate.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_1
+
+import (
+	"github.com/coreos/fcct/config/common"
+	cutil "github.com/coreos/fcct/config/util"
+
+	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_2 translates the config to an Ignition config.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_2Bytes translates from a v0.1 rcc to a v3.2.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_2Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
+}

--- a/config/rhcos/v0_2_exp/schema.go
+++ b/config/rhcos/v0_2_exp/schema.go
@@ -1,0 +1,23 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	fcos "github.com/coreos/fcct/config/fcos/v1_4_exp"
+)
+
+type Config struct {
+	fcos.Config `yaml:",inline"`
+}

--- a/config/rhcos/v0_2_exp/translate.go
+++ b/config/rhcos/v0_2_exp/translate.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v0_2_exp
+
+import (
+	"github.com/coreos/fcct/config/common"
+	cutil "github.com/coreos/fcct/config/util"
+
+	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
+	"github.com/coreos/vcontext/report"
+)
+
+// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+	return cfg.(types.Config), r, err
+}
+
+// ToIgn3_3Bytes translates from a v0.2 rcc to a v3.3.0 Ignition config. It returns a report of any errors or
+// warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
+// translating, an error is returned.
+func ToIgn3_3Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+}

--- a/docs/config-fcos-v1_0.md
+++ b/docs/config-fcos-v1_0.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: Config Spec v1.0.0
+title: Fedora CoreOS v1.0.0
 parent: Configuration specifications
 nav_order: 49
 ---
 
-# Configuration Specification v1.0.0
+# Fedora CoreOS Specification v1.0.0
 
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.0.0` and generates Ignition configs with version `3.0.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.

--- a/docs/config-fcos-v1_1.md
+++ b/docs/config-fcos-v1_1.md
@@ -1,15 +1,15 @@
 ---
 layout: default
-title: Config Spec v1.1.0
+title: Fedora CoreOS v1.1.0
 parent: Configuration specifications
 nav_order: 48
 ---
 
-# Configuration Specification v1.1.0
+# Fedora CoreOS Specification v1.1.0
 
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `1.1.0` and generates Ignition configs with version `3.1.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.

--- a/docs/config-fcos-v1_2.md
+++ b/docs/config-fcos-v1_2.md
@@ -1,18 +1,16 @@
 ---
 layout: default
-title: Config Spec v1.4.0-experimental
+title: Fedora CoreOS v1.2.0
 parent: Configuration specifications
-nav_order: 50
+nav_order: 47
 ---
 
-# Configuration Specification v1.4.0-experimental
-
-**Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
+# Fedora CoreOS Specification v1.2.0
 
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
-* **version** (string): the semantic version of the spec for this document. This document is for version `1.4.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.2.0` and generates Ignition configs with version `3.2.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
@@ -190,16 +188,6 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_gid_** (integer): the group ID of the new group.
     * **_password_hash_** (string): the hashed password of the new group.
     * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
-* **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
-  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
-  * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
-    * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
-      * **url** (string): url of the tang server.
-      * **thumbprint** (string): thumbprint of a trusted signing key.
-    * **_tpm2_** (bool): whether or not to use a tpm2 device.
-    * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
-  * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
-    * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/docs/config-fcos-v1_3.md
+++ b/docs/config-fcos-v1_3.md
@@ -1,16 +1,16 @@
 ---
 layout: default
-title: Config Spec v1.2.0
+title: Fedora CoreOS v1.3.0
 parent: Configuration specifications
-nav_order: 47
+nav_order: 46
 ---
 
-# Configuration Specification v1.2.0
+# Fedora CoreOS Specification v1.3.0
 
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
-* **version** (string): the semantic version of the spec for this document. This document is for version `1.2.0` and generates Ignition configs with version `3.2.0`.
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.3.0` and generates Ignition configs with version `3.2.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
@@ -188,6 +188,16 @@ The Fedora CoreOS configuration is a YAML document conforming to the following s
     * **_gid_** (integer): the group ID of the new group.
     * **_password_hash_** (string): the hashed password of the new group.
     * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+      * **url** (string): url of the tang server.
+      * **thumbprint** (string): thumbprint of a trusted signing key.
+    * **_tpm2_** (bool): whether or not to use a tpm2 device.
+    * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+  * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
+    * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
 
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397

--- a/docs/config-fcos-v1_4-exp.md
+++ b/docs/config-fcos-v1_4-exp.md
@@ -1,16 +1,18 @@
 ---
 layout: default
-title: Config Spec v1.3.0
+title: Fedora CoreOS v1.4.0-experimental
 parent: Configuration specifications
-nav_order: 46
+nav_order: 50
 ---
 
-# Configuration Specification v1.3.0
+# Fedora CoreOS Specification v1.4.0-experimental
+
+**Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
 
 The Fedora CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
-* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for FCCT.
-* **version** (string): the semantic version of the spec for this document. This document is for version `1.3.0` and generates Ignition configs with version `3.2.0`.
+* **variant** (string): used to differentiate configs for different operating systems. Must be `fcos` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `1.4.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.

--- a/docs/config-rhcos-v0_1.md
+++ b/docs/config-rhcos-v0_1.md
@@ -1,0 +1,204 @@
+---
+layout: default
+title: RHEL CoreOS v0.1.0
+parent: Configuration specifications
+nav_order: 99
+---
+
+# RHEL CoreOS Specification v0.1.0
+
+The RHEL CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `0.1.0` and generates Ignition configs with version `3.2.0`.
+* **ignition** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_httpProxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `httpsProxy` or `noProxy`.
+    * **_httpsProxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `noProxy`.
+    * **_noProxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
+      * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
+      * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
+      * **_wipe_partition_entry_** (boolean) if true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead.
+      * **_should_exist_** (boolean) whether or not the partition with the specified `number` should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on `wipePartitionEntry`. If false `number` must be specified and non-zero and `label`, `start`, `size`, `guid`, and `typeGuid` must all be omitted.
+  * **_raid_** (list of objects): the list of RAID arrays to be configured. Every RAID array must have a unique `name`.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. `path`, `device`, and `format` all need to be specified. Every filesystem must have a unique `device`.
+    * **path** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
+    * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+    * **_label_** (string): the label of the filesystem.
+    * **_uuid_** (string): the uuid of the filesystem.
+    * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_mount_options_** (list of strings): any special options to be passed to the mount command.
+    * **_with_mount_unit_** (bool): Whether to generate a generic mount unit for this filesystem as well. If a more specific unit is needed, a custom one can be specified in the `systemd.units` section. The unit will be named with the [escaped][systemd-escape] version of the `path`. If your filesystem is located on a Tang-backed LUKS device, the unit will automatically require network access if you specify the device as `/dev/mapper/<device-name>` or `/dev/disk/by-id/dm-name-<device-name>`.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the symbolic link's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+ * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
+    * **name** (string): the name of the luks device.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_key_file_** (string): options related to the contents of the key file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the key file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_label_** (string): the label of the luks device.
+    * **_uuid_** (string): the uuid of the luks device.
+    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_wipe_volume_** (boolean): whether or not to wipe the device before volume creation, see [the Ignition documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+    * **_clevis_** (object): describes the clevis configuration for the luks device.
+      * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+        * **url** (string): url of the tang server.
+        * **thumbprint** (string): thumbprint of a trusted signing key.
+      * **_tpm2_** (bool): whether or not to use a tpm2 device.
+      * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+      * **_custom_** (object): overrides the clevis configuration. The `pin` & `config` will be passed directly to `clevis luks bind`. If specified, all other clevis options must be omitted.
+        * **pin** (string): the clevis pin.
+        * **config** (string): the clevis configuration JSON.
+        * **_needs_network_** (bool): whether or not the device requires networking.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service"). Every unit must have a unique `name`.
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+      * **url** (string): url of the tang server.
+      * **thumbprint** (string): thumbprint of a trusted signing key.
+    * **_tpm2_** (bool): whether or not to use a tpm2 device.
+    * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+  * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
+    * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/config-rhcos-v0_2-exp.md
+++ b/docs/config-rhcos-v0_2-exp.md
@@ -1,0 +1,206 @@
+---
+layout: default
+title: RHEL CoreOS v0.2.0-experimental
+parent: Configuration specifications
+nav_order: 100
+---
+
+# RHEL CoreOS Specification v0.2.0-experimental
+
+**Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
+
+The RHEL CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+
+* **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
+* **version** (string): the semantic version of the spec for this document. This document is for version `0.2.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
+* **ignition** (object): metadata about the configuration itself.
+  * **_config_** (objects): options related to the configuration.
+    * **_merge_** (list of objects): a list of the configs to be merged to the current config.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_replace_** (object): the config that will replace the current.
+      * **_source_** (string): the URL of the config. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the config. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the config, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the config.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_timeouts_** (object): options relating to `http` timeouts when fetching files over `http` or `https`.
+    * **_http_response_headers_** (integer) the time to wait (in seconds) for the server's response headers (but not the body) after making a request. 0 indicates no timeout. Default is 10 seconds.
+    * **_http_total_** (integer) the time limit (in seconds) for the operation (connection, request, and response), including retries. 0 indicates no timeout. Default is 0.
+  * **_security_** (object): options relating to network security.
+    * **_tls_** (object): options relating to TLS when fetching resources over `https`.
+      * **_certificate_authorities_** (list of objects): the list of additional certificate authorities (in addition to the system authorities) to be used for TLS verification when fetching over `https`. All certificate authorities must have a unique `source`, `inline`, or `local`.
+        * **_source_** (string): the URL of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Supported schemes are `http`, `https`, `s3`, `tftp`, and [`data`][rfc2397]. Note: When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+        * **_inline_** (string): the contents of the certificate bundle (in PEM format). With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `local`.
+        * **_local_** (string): a local path to the contents of the certificate bundle (in PEM format), relative to the directory specified by the `--files-dir` command-line argument. With Ignition &ge; 2.4.0, the bundle can contain multiple concatenated certificates. Mutually exclusive with `source` and `inline`.
+        * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+          * **name** (string): the header name.
+          * **_value_** (string): the header contents.
+        * **_verification_** (object): options related to the verification of the certificate.
+          * **_hash_** (string): the hash of the certificate, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+  * **_proxy_** (object): options relating to setting an `HTTP(S)` proxy when fetching resources.
+    * **_httpProxy_** (string): will be used as the proxy URL for HTTP requests and HTTPS requests unless overridden by `httpsProxy` or `noProxy`.
+    * **_httpsProxy_** (string): will be used as the proxy URL for HTTPS requests unless overridden by `noProxy`.
+    * **_noProxy_** (list of strings): specifies a list of strings to hosts that should be excluded from proxying. Each value is represented by an `IP address prefix (1.2.3.4)`, `an IP address prefix in CIDR notation (1.2.3.4/8)`, `a domain name`, or `a special DNS label (*)`. An IP address prefix and domain name can also include a literal port number `(1.2.3.4:80)`. A domain name matches that name and all subdomains. A domain name with a leading `.` matches subdomains only. For example `foo.com` matches `foo.com` and `bar.foo.com`; `.y.com` matches `x.y.com` but not `y.com`. A single asterisk `(*)` indicates that no proxying should be done.
+* **_storage_** (object): describes the desired state of the system's storage devices.
+  * **_disks_** (list of objects): the list of disks to be configured and their options. Every entry must have a unique `device`.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_wipe_table_** (boolean): whether or not the partition tables shall be wiped. When true, the partition tables are erased before any further manipulation. Otherwise, the existing entries are left intact.
+    * **_partitions_** (list of objects): the list of partitions and their configuration for this particular disk. Every partition must have a unique `number`, or if 0 is specified, a unique `label`.
+      * **_label_** (string): the PARTLABEL for the partition.
+      * **_number_** (integer): the partition number, which dictates it's position in the partition table (one-indexed). If zero, use the next available partition slot.
+      * **_size_mib_** (integer): the size of the partition (in mebibytes). If zero, the partition will be made as large as possible.
+      * **_start_mib_** (integer): the start of the partition (in mebibytes). If zero, the partition will be positioned at the start of the largest block available.
+      * **_type_guid_** (string): the GPT [partition type GUID][part-types]. If omitted, the default will be 0FC63DAF-8483-4772-8E79-3D69D8477DE4 (Linux filesystem data).
+      * **_guid_** (string): the GPT unique partition GUID.
+      * **_wipe_partition_entry_** (boolean) if true, Ignition will clobber an existing partition if it does not match the config. If false (default), Ignition will fail instead.
+      * **_should_exist_** (boolean) whether or not the partition with the specified `number` should exist. If omitted, it defaults to true. If false Ignition will either delete the specified partition or fail, depending on `wipePartitionEntry`. If false `number` must be specified and non-zero and `label`, `start`, `size`, `guid`, and `typeGuid` must all be omitted.
+  * **_raid_** (list of objects): the list of RAID arrays to be configured. Every RAID array must have a unique `name`.
+    * **name** (string): the name to use for the resulting md device.
+    * **level** (string): the redundancy level of the array (e.g. linear, raid1, raid5, etc.).
+    * **devices** (list of strings): the list of devices (referenced by their absolute path) in the array.
+    * **_spares_** (integer): the number of spares (if applicable) in the array.
+    * **_options_** (list of strings): any additional options to be passed to mdadm.
+  * **_filesystems_** (list of objects): the list of filesystems to be configured. `path`, `device`, and `format` all need to be specified. Every filesystem must have a unique `device`.
+    * **path** (string): the mount-point of the filesystem while Ignition is running relative to where the root filesystem will be mounted. This is not necessarily the same as where it should be mounted in the real root, but it is encouraged to make it the same.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **format** (string): the filesystem format (ext4, btrfs, xfs, vfat, or swap).
+    * **_wipe_filesystem_** (boolean): whether or not to wipe the device before filesystem creation, see [the documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+    * **_label_** (string): the label of the filesystem.
+    * **_uuid_** (string): the uuid of the filesystem.
+    * **_options_** (list of strings): any additional options to be passed to the format-specific mkfs utility.
+    * **_mount_options_** (list of strings): any special options to be passed to the mount command.
+    * **_with_mount_unit_** (bool): Whether to generate a generic mount unit for this filesystem as well. If a more specific unit is needed, a custom one can be specified in the `systemd.units` section. The unit will be named with the [escaped][systemd-escape] version of the `path`. If your filesystem is located on a Tang-backed LUKS device, the unit will automatically require network access if you specify the device as `/dev/mapper/<device-name>` or `/dev/disk/by-id/dm-name-<device-name>`.
+  * **_files_** (list of objects): the list of files to be written. Every file, directory and link must have a unique `path`.
+    * **path** (string): the absolute path to the file.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. `contents` must be specified if `overwrite` is true. Defaults to false.
+    * **_contents_** (object): options related to the contents of the file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. If source is omitted and a regular file already exists at the path, Ignition will do nothing. If source is omitted and no file exists, an empty file will be created. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_append_** (list of objects): list of contents to be appended to the file. Follows the same stucture as `contents`
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the contents to append. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents to append. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents to append, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the appended contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_mode_** (integer): the file's permission mode. If not specified, the permission mode for files defaults to 0644 or the existing file's permissions if `overwrite` is false, `contents` is unspecified, and a file already exists at the path.
+    * **_user_** (object): specifies the file's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_directories_** (list of objects): the list of directories to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the directory.
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If false and a directory already exists at the path, Ignition will only set its permissions. If false and a non-directory exists at that path, Ignition will fail. Defaults to false.
+    * **_mode_** (integer): the directory's permission mode. If not specified, the permission mode for directories defaults to 0755 or the mode of an existing directory if `overwrite` is false and a directory already exists at the path.
+    * **_user_** (object): specifies the directory's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+  * **_links_** (list of objects): the list of links to be created. Every file, directory, and link must have a unique `path`.
+    * **path** (string): the absolute path to the link
+    * **_overwrite_** (boolean): whether to delete preexisting nodes at the path. If overwrite is false and a matching link exists at the path, Ignition will only set the owner and group. Defaults to false.
+    * **_user_** (object): specifies the symbolic link's owner.
+      * **_id_** (integer): the user ID of the owner.
+      * **_name_** (string): the user name of the owner.
+    * **_group_** (object): specifies the group of the owner.
+      * **_id_** (integer): the group ID of the owner.
+      * **_name_** (string): the group name of the owner.
+    * **target** (string): the target path of the link
+    * **_hard_** (boolean): a symbolic link is created if this is false, a hard one if this is true.
+ * **_luks_** (list of objects): the list of luks devices to be created. Every device must have a unique `name`.
+    * **name** (string): the name of the luks device.
+    * **device** (string): the absolute path to the device. Devices are typically referenced by the `/dev/disk/by-*` symlinks.
+    * **_key_file_** (string): options related to the contents of the key file.
+      * **_compression_** (string): the type of compression used on the contents (null or gzip). Compression cannot be used with S3.
+      * **_source_** (string): the URL of the key file contents. Supported schemes are `http`, `https`, `tftp`, `s3`, and [`data`][rfc2397]. When using `http`, it is advisable to use the verification option to ensure the contents haven't been modified. Mutually exclusive with `inline` and `local`.
+      * **_inline_** (string): the contents of the key file. Mutually exclusive with `source` and `local`.
+      * **_local_** (string): a local path to the contents of the key file, relative to the directory specified by the `--files-dir` command-line argument. Mutually exclusive with `source` and `inline`.
+      * **_http_headers_** (list of objects): a list of HTTP headers to be added to the request. Available for `http` and `https` source schemes only.
+        * **name** (string): the header name.
+        * **_value_** (string): the header contents.
+      * **_verification_** (object): options related to the verification of the file contents.
+        * **_hash_** (string): the hash of the config, in the form `<type>-<value>` where type is either `sha512` or `sha256`.
+    * **_label_** (string): the label of the luks device.
+    * **_uuid_** (string): the uuid of the luks device.
+    * **_options_** (list of strings): any additional options to be passed to the cryptsetup utility.
+    * **_wipe_volume_** (boolean): whether or not to wipe the device before volume creation, see [the Ignition documentation on filesystems](https://coreos.github.io/ignition/operator-notes/#filesystem-reuse-semantics) for more information.
+    * **_clevis_** (object): describes the clevis configuration for the luks device.
+      * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+        * **url** (string): url of the tang server.
+        * **thumbprint** (string): thumbprint of a trusted signing key.
+      * **_tpm2_** (bool): whether or not to use a tpm2 device.
+      * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+      * **_custom_** (object): overrides the clevis configuration. The `pin` & `config` will be passed directly to `clevis luks bind`. If specified, all other clevis options must be omitted.
+        * **pin** (string): the clevis pin.
+        * **config** (string): the clevis configuration JSON.
+        * **_needs_network_** (bool): whether or not the device requires networking.
+  * **_trees_** (list of objects): a list of local directory trees to be embedded in the config. Ownership is not preserved. File modes are set to 0755 if the local file is executable or 0644 otherwise. Attributes of files, directories, and symlinks can be overridden by creating a corresponding entry in the `files`, `directories`, or `links` section; such `files` entries must omit `contents` and such `links` entries must omit `target`.
+    * **local** (string): the base of the local directory tree, relative to the directory specified by the `--files-dir` command-line argument.
+    * **_path_** (string): the path of the tree within the target system. Defaults to `/`.
+* **_systemd_** (object): describes the desired state of the systemd units.
+  * **_units_** (list of objects): the list of systemd units.
+    * **name** (string): the name of the unit. This must be suffixed with a valid unit type (e.g. "thing.service"). Every unit must have a unique `name`.
+    * **_enabled_** (boolean): whether or not the service shall be enabled. When true, the service is enabled. When false, the service is disabled. When omitted, the service is unmodified. In order for this to have any effect, the unit must have an install section.
+    * **_mask_** (boolean): whether or not the service shall be masked. When true, the service is masked by symlinking it to `/dev/null`.
+    * **_contents_** (string): the contents of the unit.
+    * **_dropins_** (list of objects): the list of drop-ins for the unit. Every drop-in must have a unique `name`.
+      * **name** (string): the name of the drop-in. This must be suffixed with ".conf".
+      * **_contents_** (string): the contents of the drop-in.
+* **_passwd_** (object): describes the desired additions to the passwd database.
+  * **_users_** (list of objects): the list of accounts that shall exist. All users must have a unique `name`.
+    * **name** (string): the username for the account.
+    * **_password_hash_** (string): the hashed password for the account.
+    * **_ssh_authorized_keys_** (list of strings): a list of SSH keys to be added as an SSH key fragment at `.ssh/authorized_keys.d/ignition` in the user's home directory. All SSH keys must be unique.
+    * **_uid_** (integer): the user ID of the account.
+    * **_gecos_** (string): the GECOS field of the account.
+    * **_home_dir_** (string): the home directory of the account.
+    * **_no_create_home_** (boolean): whether or not to create the user's home directory. This only has an effect if the account doesn't exist yet.
+    * **_primary_group_** (string): the name of the primary group of the account.
+    * **_groups_** (list of strings): the list of supplementary groups of the account.
+    * **_no_user_group_** (boolean): whether or not to create a group with the same name as the user. This only has an effect if the account doesn't exist yet.
+    * **_no_log_init_** (boolean): whether or not to add the user to the lastlog and faillog databases. This only has an effect if the account doesn't exist yet.
+    * **_shell_** (string): the login shell of the new account.
+    * **_system_** (bool): whether or not this account should be a system account. This only has an effect if the account doesn't exist yet.
+  * **_groups_** (list of objects): the list of groups to be added. All groups must have a unique `name`.
+    * **name** (string): the name of the group.
+    * **_gid_** (integer): the group ID of the new group.
+    * **_password_hash_** (string): the hashed password of the new group.
+    * **_system_** (bool): whether or not the group should be a system group. This only has an effect if the group doesn't exist yet.
+* **_boot_device_** (object): describes the desired boot device configuration. At least one of `luks` or `mirror` must be specified.
+  * **_layout_** (string): the disk layout of the target OS image. Supported values are `aarch64`, `ppc64le`, and `x86_64`. Defaults to `x86_64`.
+  * **_luks_** (object): describes the clevis configuration for encrypting the root filesystem.
+    * **_tang_** (list of objects): describes a tang server. Every server must have a unique `url`.
+      * **url** (string): url of the tang server.
+      * **thumbprint** (string): thumbprint of a trusted signing key.
+    * **_tpm2_** (bool): whether or not to use a tpm2 device.
+    * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
+  * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
+    * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
+
+[part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
+[rfc2397]: https://tools.ietf.org/html/rfc2397
+[systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -7,17 +7,13 @@ has_toc: false
 
 # Configuration specifications
 
-Fedora CoreOS Configs must conform to a specific version of the `fcct` schema,
-specified with the `version: X.Y.Z` field in the configuration.
+Fedora CoreOS Configs must conform to a specific version of the `fcct` schema, specified with the `version: X.Y.Z` field in the configuration.
 
-See the [Upgrading Configs](migrating-configs.md) page for instructions to
-update a configuration to the latest specification.
+See the [Upgrading Configs](migrating-configs.md) page for instructions to update a configuration to the latest specification.
 
 ## Stable specification versions
 
-We recommend that you always use the latest **stable** specification to benefit
-from new features and bug fixes. The following **stable** specification
-versions are currently supported in `fcct`:
+We recommend that you always use the latest **stable** specification to benefit from new features and bug fixes. The following **stable** specification versions are currently supported in `fcct`:
 
 - [v1.3.0](configuration-v1_3.md)
 - [v1.2.0](configuration-v1_2.md)
@@ -26,17 +22,13 @@ versions are currently supported in `fcct`:
 
 ## Experimental specification versions
 
-Do not use the **experimental** specification for anything beyond **development
-and testing** as it is subject to change **without warning or announcement**.
-The following **experimental** specification version is currently available in
-`fcct`:
+Do not use the **experimental** specification for anything beyond **development and testing** as it is subject to change **without warning or announcement**. The following **experimental** specification version is currently available in `fcct`:
 
 - [v1.4.0-experimental](configuration-v1_4-exp.md)
 
 ## FCCT specifications and Ignition specifications
 
-Each version of the FCCT specification corresponds to a version of the Ignition
-specification:
+Each version of the FCCT specification corresponds to a version of the Ignition specification:
 
 | FCCT spec          | Igntion spec       |
 |--------------------|--------------------|

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -7,33 +7,35 @@ has_toc: false
 
 # Configuration specifications
 
-Fedora CoreOS Configs must conform to a specific version of the `fcct` schema, specified with the `version: X.Y.Z` field in the configuration.
+CoreOS Configs must conform to a specific variant and version of the `fcct` schema, specified with the `variant` and `version` fields in the configuration.
 
 See the [Upgrading Configs](migrating-configs.md) page for instructions to update a configuration to the latest specification.
 
 ## Stable specification versions
 
-We recommend that you always use the latest **stable** specification to benefit from new features and bug fixes. The following **stable** specification versions are currently supported in `fcct`:
+We recommend that you always use the latest **stable** specification for your operating system to benefit from new features and bug fixes. The following **stable** specification versions are currently supported in `fcct`:
 
-- [v1.3.0](configuration-v1_3.md)
-- [v1.2.0](configuration-v1_2.md)
-- [v1.1.0](configuration-v1_1.md)
-- [v1.0.0](configuration-v1_0.md)
+- Fedora CoreOS (`fcos`)
+  - [v1.3.0](config-fcos-v1_3.md)
+  - [v1.2.0](config-fcos-v1_2.md)
+  - [v1.1.0](config-fcos-v1_1.md)
+  - [v1.0.0](config-fcos-v1_0.md)
 
 ## Experimental specification versions
 
-Do not use the **experimental** specification for anything beyond **development and testing** as it is subject to change **without warning or announcement**. The following **experimental** specification version is currently available in `fcct`:
+Do not use **experimental** specifications for anything beyond **development and testing** as they are subject to change **without warning or announcement**. The following **experimental** specification versions are currently available in `fcct`:
 
-- [v1.4.0-experimental](configuration-v1_4-exp.md)
+- Fedora CoreOS (`fcos`)
+  - [v1.4.0-experimental](config-fcos-v1_4-exp.md)
 
-## FCCT specifications and Ignition specifications
+## FCC specifications and Ignition specifications
 
-Each version of the FCCT specification corresponds to a version of the Ignition specification:
+Each version of the FCC specification corresponds to a version of the Ignition specification:
 
-| FCCT spec          | Igntion spec       |
-|--------------------|--------------------|
-| 1.0.0              | 3.0.0              |
-| 1.1.0              | 3.1.0              |
-| 1.2.0              | 3.2.0              |
-| 1.3.0              | 3.2.0              |
-| 1.4.0-experimental | 3.3.0-experimental |
+| FCC variant | FCC version        | Ignition spec      |
+|-------------|--------------------|--------------------|
+| `fcos`      | 1.0.0              | 3.0.0              |
+| `fcos`      | 1.1.0              | 3.1.0              |
+| `fcos`      | 1.2.0              | 3.2.0              |
+| `fcos`      | 1.3.0              | 3.2.0              |
+| `fcos`      | 1.4.0-experimental | 3.3.0-experimental |

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -20,6 +20,8 @@ We recommend that you always use the latest **stable** specification for your op
   - [v1.2.0](config-fcos-v1_2.md)
   - [v1.1.0](config-fcos-v1_1.md)
   - [v1.0.0](config-fcos-v1_0.md)
+- RHEL CoreOS (`rhcos`)
+  - [v0.1.0](config-rhcos-v0_1.md)
 
 ## Experimental specification versions
 
@@ -27,6 +29,8 @@ Do not use **experimental** specifications for anything beyond **development and
 
 - Fedora CoreOS (`fcos`)
   - [v1.4.0-experimental](config-fcos-v1_4-exp.md)
+- RHEL CoreOS (`rhcos`)
+  - [v0.2.0-experimental](config-rhcos-v0_2-exp.md)
 
 ## FCC specifications and Ignition specifications
 
@@ -39,3 +43,5 @@ Each version of the FCC specification corresponds to a version of the Ignition s
 | `fcos`      | 1.2.0              | 3.2.0              |
 | `fcos`      | 1.3.0              | 3.2.0              |
 | `fcos`      | 1.4.0-experimental | 3.3.0-experimental |
+| `rhcos`     | 0.1.0              | 3.2.0              |
+| `rhcos`     | 0.2.0-experimental | 3.3.0-experimental |


### PR DESCRIPTION
Add an `rhcos` variant with `version` `0.1.0` as an alias for `fcos` `1.3.0`, and an `0.2.0-experimental` spec as an alias for `fcos 1.4.0-experimental`.  Specialize spec docs to handle each variant/version pair independently.

The idea behind `0.1.0` is to get this spec released in a usable form and gain some experience with RHCOS users using it.  We might then want to add RHCOS-specific validation, which would further restrict the set of valid configs and thus be a breaking change.  That development would eventually be stabilized as a `1.0.0` spec.