### PR TITLE
test: use vendored Go packages

### DIFF
--- a/test
+++ b/test
@@ -2,6 +2,7 @@
 set -euo pipefail
 
 export GO111MODULE=on
+export GOFLAGS=-mod=vendor
 
 SRC=$(find . -name '*.go' -not -path "./vendor/*")
 


### PR DESCRIPTION
Test what we ship.  Also useful for hand-hacking the vendor directory during debugging.