### PR TITLE
README: move project layout section to dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,53 +3,5 @@
 The Fedora CoreOS Config Transpiler (FCCT) translates human readable Fedora CoreOS Configs (FCCs)
 into machine readable [Ignition](https://github.com/coreos/ignition) Configs. See the [getting
 started](docs/getting-started.md) guide for how to use FCCT and the [configuration
-specifications](docs/specs.md) for everything FCCs support.
-
-### Project Layout
-
-Internally, FCCT has a versioned `base` component which contains support for
-a particular Ignition spec version, plus distro-independent sugar. New base
-functionality is added only to the experimental base package. Eventually the
-experimental base package is stabilized and a new experimental package
-created. The base component is versioned independently of any particular
-distro, and its versions are not exposed to the user. Client code should
-not need to import anything from `base`.
-
-Each FCC variant/version pair corresponds to a `config` package, which
-derives either from a `base` package or from another `config` package. New
-functionality is similarly added only to an experimental config version,
-which is eventually stabilized and a new experimental version created.
-(This will often happen when the underlying package is stabilized.) A
-`config` package can contain sugar or validation logic specific to a distro
-(for example, additional properties for configuring etcd).
-
-Packages outside the FCCT repository can implement additional FCC versions
-by deriving from a `base` or `config` package and registering their
-variant/version pair with `config`.
-
-`config/`
-  Top-level `TranslateBytes()` function that determines which config version
-  to parse and emit. Clients should typically use this to translate FCCs.
-
-`config/common/`
-  Common definitions for all spec versions, including translate options
-  structs and error definitions.
-
-`config/*/vX_Y/`
-  User facing definitions of the spec. Each is derived from another config
-  package or from a base package. Each one defines its own translate
-  functions to be registered in the `config` package. Clients can use
-  these directly if they want to translate a specific spec version.
-
-`config/util/`
-  Utility code for implementing config packages, including the
-  (un)marshaling helpers. Clients don't need to import this unless they're
-  implementing an out-of-tree config version.
-
-`base/`
-  Distro-agnostic code targeting individual Ignition spec versions. Clients
-  don't need to import this unless they're implementing an out-of-tree
-  config version.
-
-`internal/`
-  `main`, non-exported code.
+specifications](docs/specs.md) for everything FCCs support. For information on developing FCCT
+or using it as a library, see the [development docs](docs/development.md).

--- a/docs/development.md
+++ b/docs/development.md
@@ -31,31 +31,31 @@ Packages outside the FCCT repository can implement additional FCC versions
 by deriving from a `base` or `config` package and registering their
 variant/version pair with `config`.
 
-`config/`
+- `config/` &mdash;
   Top-level `TranslateBytes()` function that determines which config version
   to parse and emit. Clients should typically use this to translate FCCs.
 
-`config/common/`
+- `config/common/` &mdash;
   Common definitions for all spec versions, including translate options
   structs and error definitions.
 
-`config/*/vX_Y/`
+- `config/*/vX_Y/` &mdash;
   User facing definitions of the spec. Each is derived from another config
   package or from a base package. Each one defines its own translate
   functions to be registered in the `config` package. Clients can use
   these directly if they want to translate a specific spec version.
 
-`config/util/`
+- `config/util/` &mdash;
   Utility code for implementing config packages, including the
   (un)marshaling helpers. Clients don't need to import this unless they're
   implementing an out-of-tree config version.
 
-`base/`
+- `base/` &mdash;
   Distro-agnostic code targeting individual Ignition spec versions. Clients
   don't need to import this unless they're implementing an out-of-tree
   config version.
 
-`internal/`
+- `internal/` &mdash;
   `main`, non-exported code.
 
 ## Creating a release

--- a/docs/development.md
+++ b/docs/development.md
@@ -9,6 +9,55 @@ nav_order: 9
 1. TOC
 {:toc}
 
+## Project layout
+
+Internally, FCCT has a versioned `base` component which contains support for
+a particular Ignition spec version, plus distro-independent sugar. New base
+functionality is added only to the experimental base package. Eventually the
+experimental base package is stabilized and a new experimental package
+created. The base component is versioned independently of any particular
+distro, and its versions are not exposed to the user. Client code should
+not need to import anything from `base`.
+
+Each FCC variant/version pair corresponds to a `config` package, which
+derives either from a `base` package or from another `config` package. New
+functionality is similarly added only to an experimental config version,
+which is eventually stabilized and a new experimental version created.
+(This will often happen when the underlying package is stabilized.) A
+`config` package can contain sugar or validation logic specific to a distro
+(for example, additional properties for configuring etcd).
+
+Packages outside the FCCT repository can implement additional FCC versions
+by deriving from a `base` or `config` package and registering their
+variant/version pair with `config`.
+
+`config/`
+  Top-level `TranslateBytes()` function that determines which config version
+  to parse and emit. Clients should typically use this to translate FCCs.
+
+`config/common/`
+  Common definitions for all spec versions, including translate options
+  structs and error definitions.
+
+`config/*/vX_Y/`
+  User facing definitions of the spec. Each is derived from another config
+  package or from a base package. Each one defines its own translate
+  functions to be registered in the `config` package. Clients can use
+  these directly if they want to translate a specific spec version.
+
+`config/util/`
+  Utility code for implementing config packages, including the
+  (un)marshaling helpers. Clients don't need to import this unless they're
+  implementing an out-of-tree config version.
+
+`base/`
+  Distro-agnostic code targeting individual Ignition spec versions. Clients
+  don't need to import this unless they're implementing an out-of-tree
+  config version.
+
+`internal/`
+  `main`, non-exported code.
+
 ## Creating a release
 
 Create a [release checklist](https://github.com/coreos/fcct/issues/new?template=release-checklist.md) and follow those steps.


### PR DESCRIPTION
The layout docs are relevant to developers and folks wanting to use FCCT as a library, but not to users, and they're currently taking up most of the GitHub front page.  Move them to dev docs, where they'll also show up in GitHub Pages.