### PR TITLE
Stop building non-Linux-x86_64 binaries during container build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,8 @@ FROM golang:latest AS builder
 RUN mkdir /fcct
 COPY . /fcct
 WORKDIR /fcct
-RUN ./build_releases
+RUN ./build_for_container
 
 FROM scratch
-COPY --from=builder /fcct/bin/releases/fcct-x86_64-unknown-linux-gnu /usr/local/bin/fcct
+COPY --from=builder /fcct/bin/container/fcct-x86_64-unknown-linux-gnu /usr/local/bin/fcct
 ENTRYPOINT ["/usr/local/bin/fcct"]

--- a/build_for_container
+++ b/build_for_container
@@ -22,15 +22,3 @@ build_release() {
 export GOOS=linux
 export GOARCH=amd64
 build_release x86_64-unknown-linux-gnu
-
-export GOOS=darwin
-export GOARCH=amd64
-build_release x86_64-apple-darwin
-
-export GOOS=windows
-export GOARCH=amd64
-build_release x86_64-pc-windows-gnu.exe
-
-export GOOS=linux
-export GOARCH=arm64
-build_release aarch64-unknown-linux-gnu

--- a/build_for_container
+++ b/build_for_container
@@ -10,7 +10,7 @@ LDFLAGS="-w -X github.com/coreos/fcct/internal/version.Raw=$version"
 
 eval $(go env)
 if [ -z ${BIN_PATH+a} ]; then
-	export BIN_PATH=${PWD}/bin/releases/
+	export BIN_PATH=${PWD}/bin/container/
 fi
 
 build_release() {


### PR DESCRIPTION
We don't use them in the resulting container.

Also rename `build_releases` to clarify that it's only used for the container build now.

Fixes https://github.com/coreos/fcct/issues/151.