### PR TITLE
config/fcos: Avoid merging invalid configs

### DIFF
--- a/config/fcos/v1_3/translate.go
+++ b/config/fcos/v1_3/translate.go
@@ -63,6 +63,9 @@ const (
 // validation is performed on input or output.
 func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	ret, ts, r := c.Config.ToIgn3_2Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	return ret, ts, r
 }

--- a/config/fcos/v1_4_exp/translate.go
+++ b/config/fcos/v1_4_exp/translate.go
@@ -63,6 +63,9 @@ const (
 // validation is performed on input or output.
 func (c Config) ToIgn3_3Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	ret, ts, r := c.Config.ToIgn3_3Unvalidated(options)
+	if r.IsFatal() {
+		return types.Config{}, translate.TranslationSet{}, r
+	}
 	r.Merge(c.processBootDevice(&ret, &ts, options))
 	return ret, ts, r
 }


### PR DESCRIPTION
When the boot_device mirror functionality was added we added
`ToIgn3_XUnvalidated` functions to the `fcos` `v1_3` & `v1_4_exp`
configs which were not checking that the base configs were valid before
attempting to merge in child configs. Add a quick check that the report
for the base config is not fatal before continuing.

Fixes #192 