### PR TITLE
docs: fix `resize` example

### DIFF
--- a/docs/migrating-configs.md
+++ b/docs/migrating-configs.md
@@ -58,7 +58,8 @@ storage:
   disks:
     - device: /dev/sda
       partitions:
-        - label: root
+        - number: 4
+          label: root
           size_mib: 16384
           resize: true
 ```


### PR DESCRIPTION
The example there doesn't work as one would expect: it actually creates
a new partition labeled `root` with the given size. We need to pin it
using the partition number to make sure it affects the existing one.