### PR TITLE
Improve TranslationSet observability, add some tests

### DIFF
--- a/config/common/common.go
+++ b/config/common/common.go
@@ -17,6 +17,7 @@ package common
 type TranslateOptions struct {
 	FilesDir                  string // allow embedding local files relative to this directory
 	NoResourceAutoCompression bool   // skip automatic compression of inline/local resources
+	DebugPrintTranslations    bool   // report translations to stderr
 }
 
 type TranslateBytesOptions struct {

--- a/config/fcos/v1_0/validate_test.go
+++ b/config/fcos/v1_0/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2021 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.)
 
-package v1_3
+package v1_0
 
 import (
 	"testing"
 
-	base "github.com/coreos/fcct/base/v0_3"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/vcontext/path"
-	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -52,7 +48,7 @@ func TestReportCorrelation(t *testing.T) {
                                source: https://example.com
                                inline: z`,
 			common.ErrTooManyResourceSources.Error(),
-			5,
+			6, // variant behavior in base 0.1
 		},
 		// FCCT YAML validation warning
 		{
@@ -62,16 +58,6 @@ func TestReportCorrelation(t *testing.T) {
                              mode: 644`,
 			common.ErrDecimalMode.Error(),
 			4,
-		},
-		// FCCT translation error
-		{
-			`storage:
-                           files:
-                           - path: /z
-                             contents:
-                               local: z`,
-			common.ErrNoFilesDir.Error(),
-			5,
 		},
 		// Ignition validation error, leaf node
 		{
@@ -115,70 +101,10 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
+		_, r, _ := ToIgn3_0Bytes([]byte(test.in), common.TranslateBytesOptions{})
 		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
 		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
 		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
 		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
-	}
-}
-
-// TestValidateBootDevice tests boot device validation
-func TestValidateBootDevice(t *testing.T) {
-	tests := []struct {
-		in      BootDevice
-		out     error
-		errPath path.ContextPath
-	}{
-		// empty config
-		{
-			BootDevice{},
-			nil,
-			path.New("yaml"),
-		},
-		// complete config
-		{
-			BootDevice{
-				Layout: util.StrToPtr("x86_64"),
-				Luks: BootDeviceLuks{
-					Tang: []base.Tang{{
-						URL:        "https://example.com/",
-						Thumbprint: util.StrToPtr("x"),
-					}},
-					Threshold: util.IntToPtr(2),
-					Tpm2:      util.BoolToPtr(true),
-				},
-				Mirror: BootDeviceMirror{
-					Devices: []string{"/dev/vda", "/dev/vdb"},
-				},
-			},
-			nil,
-			path.New("yaml"),
-		},
-		// invalid layout
-		{
-			BootDevice{
-				Layout: util.StrToPtr("sparc"),
-			},
-			common.ErrUnknownBootDeviceLayout,
-			path.New("yaml", "layout"),
-		},
-		// only one mirror device
-		{
-			BootDevice{
-				Mirror: BootDeviceMirror{
-					Devices: []string{"/dev/vda"},
-				},
-			},
-			common.ErrTooFewMirrorDevices,
-			path.New("yaml", "mirror", "devices"),
-		},
-	}
-
-	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
 	}
 }

--- a/config/fcos/v1_2/validate_test.go
+++ b/config/fcos/v1_2/validate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2021 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,18 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.)
 
-package v1_3
+package v1_2
 
 import (
 	"testing"
 
-	base "github.com/coreos/fcct/base/v0_3"
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
-	"github.com/coreos/ignition/v2/config/util"
-	"github.com/coreos/vcontext/path"
-	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -120,65 +116,5 @@ func TestReportCorrelation(t *testing.T) {
 		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
 		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
 		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
-	}
-}
-
-// TestValidateBootDevice tests boot device validation
-func TestValidateBootDevice(t *testing.T) {
-	tests := []struct {
-		in      BootDevice
-		out     error
-		errPath path.ContextPath
-	}{
-		// empty config
-		{
-			BootDevice{},
-			nil,
-			path.New("yaml"),
-		},
-		// complete config
-		{
-			BootDevice{
-				Layout: util.StrToPtr("x86_64"),
-				Luks: BootDeviceLuks{
-					Tang: []base.Tang{{
-						URL:        "https://example.com/",
-						Thumbprint: util.StrToPtr("x"),
-					}},
-					Threshold: util.IntToPtr(2),
-					Tpm2:      util.BoolToPtr(true),
-				},
-				Mirror: BootDeviceMirror{
-					Devices: []string{"/dev/vda", "/dev/vdb"},
-				},
-			},
-			nil,
-			path.New("yaml"),
-		},
-		// invalid layout
-		{
-			BootDevice{
-				Layout: util.StrToPtr("sparc"),
-			},
-			common.ErrUnknownBootDeviceLayout,
-			path.New("yaml", "layout"),
-		},
-		// only one mirror device
-		{
-			BootDevice{
-				Mirror: BootDeviceMirror{
-					Devices: []string{"/dev/vda"},
-				},
-			},
-			common.ErrTooFewMirrorDevices,
-			path.New("yaml", "mirror", "devices"),
-		},
-	}
-
-	for i, test := range tests {
-		actual := test.in.Validate(path.New("yaml"))
-		expected := report.Report{}
-		expected.AddOnError(test.errPath, test.out)
-		assert.Equal(t, expected, actual, "#%d: bad validation report", i)
 	}
 }

--- a/config/util/util.go
+++ b/config/util/util.go
@@ -16,6 +16,8 @@ package util
 
 import (
 	"bytes"
+	"fmt"
+	"os"
 	"reflect"
 	"regexp"
 	"strings"
@@ -63,6 +65,9 @@ func Translate(cfg interface{}, translateMethod string, options common.Translate
 	r.Merge(translateReport)
 	if r.IsFatal() {
 		return zeroValue, r, common.ErrInvalidSourceConfig
+	}
+	if options.DebugPrintTranslations {
+		fmt.Fprint(os.Stderr, translations)
 	}
 
 	// Check for invalid duplicated keys.

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ require (
 	github.com/clarketm/json v1.14.1
 	github.com/coreos/go-semver v0.3.0
 	github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e
-	github.com/coreos/ignition/v2 v2.8.1
+	github.com/coreos/ignition/v2 v2.9.0
 	github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -49,8 +49,8 @@ github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e h1:Wf6HqHfScWJN9
 github.com/coreos/go-systemd v0.0.0-20190321100706-95778dfbb74e/go.mod h1:F5haX7vjVVG0kc13fIWeqUViNPyEJxv/OmvnBo0Yme4=
 github.com/coreos/go-systemd/v22 v22.0.0 h1:XJIw/+VlJ+87J+doOxznsAWIdmWuViOVhkQamW5YV28=
 github.com/coreos/go-systemd/v22 v22.0.0/go.mod h1:xO0FLkIi5MaZafQlIrOotqXZ90ih+1atmu1JpKERPPk=
-github.com/coreos/ignition/v2 v2.8.1 h1:gKCX6NwGGFh866MvpJlq2ZCqppVbWK0DA/uflL34tDU=
-github.com/coreos/ignition/v2 v2.8.1/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
+github.com/coreos/ignition/v2 v2.9.0 h1:Zl5N08OyqlECB8BrBlMDp3Jf1ShwVTtREPcUq/YO034=
+github.com/coreos/ignition/v2 v2.9.0/go.mod h1:A5lFFzA2/zvZQPVEvI1lR5WPLWRb7KZ7Q1QOeUMtcAc=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c h1:jA28WeORitsxGFVWhyWB06sAG2HbLHPQuHwDydhU2CQ=
 github.com/coreos/vcontext v0.0.0-20201120045928-b0e13dab675c/go.mod h1:z4pMVvaUrxs98RROlIYdAQCKhEicjnTirOaVyDRH5h8=
 github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=

--- a/internal/main.go
+++ b/internal/main.go
@@ -41,6 +41,8 @@ func main() {
 	options := common.TranslateBytesOptions{}
 	pflag.BoolVarP(&helpFlag, "help", "h", false, "show usage and exit")
 	pflag.BoolVarP(&versionFlag, "version", "V", false, "print the version and exit")
+	pflag.BoolVarP(&options.DebugPrintTranslations, "debug", "D", false, "log translations")
+	pflag.Lookup("debug").Hidden = true
 	pflag.BoolVarP(&options.Strict, "strict", "s", false, "fail on any warning")
 	pflag.BoolVarP(&options.Pretty, "pretty", "p", false, "output formatted json")
 	pflag.StringVar(&input, "input", "", "read from input file instead of stdin")

--- a/test
+++ b/test
@@ -5,8 +5,10 @@ SRC=$(find . -name '*.go' -not -path "./vendor/*")
 
 echo "checking gofmt"
 res=$(gofmt -d $SRC)
-echo -n "$res"
-test -z "$res"
+if [ -n "$res" ]; then
+    echo "$res"
+    exit 1
+fi
 
 echo "checking govet"
 PKG_VET=$(go list ./... | grep --invert-match vendor)

--- a/translate/translate.go
+++ b/translate/translate.go
@@ -177,11 +177,7 @@ func (t translator) translate(vFrom, vTo reflect.Value, fromPath, toPath path.Co
 
 		// handle all the translations and "rebase" them to our current place
 		retSet := returns[1].Interface().(TranslationSet)
-		for _, trans := range retSet.Set {
-			from := fromPath.Append(trans.From.Path...)
-			to := toPath.Append(trans.To.Path...)
-			t.translations.AddTranslation(from, to)
-		}
+		t.translations.Merge(retSet.PrefixPaths(fromPath, toPath))
 
 		// likewise for the report entries
 		retReport := returns[2].Interface().(report.Report)

--- a/vendor/github.com/coreos/ignition/v2/config/merge/merge.go
+++ b/vendor/github.com/coreos/ignition/v2/config/merge/merge.go
@@ -293,7 +293,7 @@ func mergeStruct(parent reflect.Value, parentPath path.ContextPath, child reflec
 						} else {
 							panic("List of pointers or slices or something else weird")
 						}
-					} else {
+					} else { // nolint:staticcheck
 						// case 2: in child config in different list. Do nothing since it'll be handled iterating over that list
 					}
 				} else {

--- a/vendor/github.com/coreos/ignition/v2/config/shared/errors/errors.go
+++ b/vendor/github.com/coreos/ignition/v2/config/shared/errors/errors.go
@@ -46,7 +46,7 @@ var (
 	ErrVerificationAndNilSource  = errors.New("source must be specified if verification is specified")
 	ErrFilesystemInvalidFormat   = errors.New("invalid filesystem format")
 	ErrLabelNeedsFormat          = errors.New("filesystem must specify format if label is specified")
-	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, or options are specified")
+	ErrFormatNilWithOthers       = errors.New("format cannot be empty when path, label, uuid, wipeFilesystem, options, or mountOptions is specified")
 	ErrExt4LabelTooLong          = errors.New("filesystem labels cannot be longer than 16 characters when using ext4")
 	ErrBtrfsLabelTooLong         = errors.New("filesystem labels cannot be longer than 256 characters when using btrfs")
 	ErrXfsLabelTooLong           = errors.New("filesystem labels cannot be longer than 12 characters when using xfs")

--- a/vendor/github.com/coreos/ignition/v2/config/v3_0/types/filesystem.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_0/types/filesystem.go
@@ -49,6 +49,7 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_0/types/partition.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_0/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/vendor/github.com/coreos/ignition/v2/config/v3_1/types/filesystem.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_1/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_1/types/partition.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_1/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/vendor/github.com/coreos/ignition/v2/config/v3_2/types/filesystem.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_2/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_2/types/partition.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_2/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/vendor/github.com/coreos/ignition/v2/config/v3_3_experimental/types/filesystem.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_3_experimental/types/filesystem.go
@@ -50,6 +50,8 @@ func (f Filesystem) validateFormat() error {
 		if util.NotEmpty(f.Path) ||
 			util.NotEmpty(f.Label) ||
 			util.NotEmpty(f.UUID) ||
+			f.WipeFilesystem != nil && *f.WipeFilesystem ||
+			len(f.MountOptions) != 0 ||
 			len(f.Options) != 0 {
 			return errors.ErrFormatNilWithOthers
 		}

--- a/vendor/github.com/coreos/ignition/v2/config/v3_3_experimental/types/partition.go
+++ b/vendor/github.com/coreos/ignition/v2/config/v3_3_experimental/types/partition.go
@@ -36,8 +36,10 @@ var (
 func (p Partition) Key() string {
 	if p.Number != 0 {
 		return fmt.Sprintf("number:%d", p.Number)
-	} else {
+	} else if p.Label != nil {
 		return fmt.Sprintf("label:%s", *p.Label)
+	} else {
+		return ""
 	}
 }
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -8,7 +8,7 @@ github.com/coreos/go-semver/semver
 github.com/coreos/go-systemd/unit
 # github.com/coreos/go-systemd/v22 v22.0.0
 github.com/coreos/go-systemd/v22/unit
-# github.com/coreos/ignition/v2 v2.8.1
+# github.com/coreos/ignition/v2 v2.9.0
 github.com/coreos/ignition/v2/config/merge
 github.com/coreos/ignition/v2/config/shared/errors
 github.com/coreos/ignition/v2/config/shared/validations


### PR DESCRIPTION
The consequences of an incorrect TranslationSet are subtle, since it only affects line/column correlation in Report entries.  Add some correlation tests and a hidden debug option to report the final set of translations.