### PR TITLE
Add openshift/4.8.0-exp that produces MachineConfigs by default

### DIFF
--- a/config/common/common.go
+++ b/config/common/common.go
@@ -23,5 +23,6 @@ type TranslateOptions struct {
 type TranslateBytesOptions struct {
 	TranslateOptions
 	Pretty bool
+	Raw    bool // encode only the Ignition config, not any wrapper
 	Strict bool
 }

--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -46,4 +46,7 @@ var (
 	// boot device
 	ErrUnknownBootDeviceLayout = errors.New("layout must be one of: aarch64, ppc64le, x86_64")
 	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
+
+	// MachineConfigs
+	ErrNameRequired = errors.New("metadata.name is required")
 )

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ func init() {
 	RegisterTranslator("fcos", "1.2.0", fcos1_2.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0-experimental", fcos1_4_exp.ToIgn3_3Bytes)
-	RegisterTranslator("openshift", "4.8.0-experimental", openshift4_8_exp.ToIgn3_2Bytes)
+	RegisterTranslator("openshift", "4.8.0-experimental", openshift4_8_exp.ToConfigBytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -47,7 +47,7 @@ func init() {
 	RegisterTranslator("fcos", "1.2.0", fcos1_2.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0-experimental", fcos1_4_exp.ToIgn3_3Bytes)
-	RegisterTranslator("openshift", "4.8.0-experimental", openshift4_8_exp.ToIgn3_3Bytes)
+	RegisterTranslator("openshift", "4.8.0-experimental", openshift4_8_exp.ToIgn3_2Bytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -23,8 +23,8 @@ import (
 	fcos1_2 "github.com/coreos/fcct/config/fcos/v1_2"
 	fcos1_3 "github.com/coreos/fcct/config/fcos/v1_3"
 	fcos1_4_exp "github.com/coreos/fcct/config/fcos/v1_4_exp"
+	openshift4_8_exp "github.com/coreos/fcct/config/openshift/v4_8_exp"
 	rhcos0_1 "github.com/coreos/fcct/config/rhcos/v0_1"
-	rhcos0_2_exp "github.com/coreos/fcct/config/rhcos/v0_2_exp"
 
 	"github.com/coreos/go-semver/semver"
 	"github.com/coreos/vcontext/report"
@@ -47,8 +47,8 @@ func init() {
 	RegisterTranslator("fcos", "1.2.0", fcos1_2.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.3.0", fcos1_3.ToIgn3_2Bytes)
 	RegisterTranslator("fcos", "1.4.0-experimental", fcos1_4_exp.ToIgn3_3Bytes)
+	RegisterTranslator("openshift", "4.8.0-experimental", openshift4_8_exp.ToIgn3_3Bytes)
 	RegisterTranslator("rhcos", "0.1.0", rhcos0_1.ToIgn3_2Bytes)
-	RegisterTranslator("rhcos", "0.2.0-experimental", rhcos0_2_exp.ToIgn3_3Bytes)
 }
 
 /// RegisterTranslator registers a translator for the specified variant and

--- a/config/openshift/v4_8_exp/result/schema.go
+++ b/config/openshift/v4_8_exp/result/schema.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package result
+
+import (
+	"github.com/coreos/ignition/v2/config/v3_2/types"
+)
+
+// We round-trip through JSON because Ignition uses `json` struct tags,
+// so all struct tags need to be `json` even though we're ultimately
+// writing YAML.
+
+type MachineConfig struct {
+	ApiVersion string   `json:"apiVersion"`
+	Kind       string   `json:"kind"`
+	Metadata   Metadata `json:"metadata"`
+	Spec       Spec     `json:"spec"`
+}
+
+type Metadata struct {
+	Name   string            `json:"name"`
+	Labels map[string]string `json:"labels,omitempty"`
+}
+
+type Spec struct {
+	Config types.Config `json:"config"`
+}

--- a/config/openshift/v4_8_exp/schema.go
+++ b/config/openshift/v4_8_exp/schema.go
@@ -15,7 +15,7 @@
 package v4_8_exp
 
 import (
-	fcos "github.com/coreos/fcct/config/fcos/v1_4_exp"
+	fcos "github.com/coreos/fcct/config/fcos/v1_3"
 )
 
 type Config struct {

--- a/config/openshift/v4_8_exp/schema.go
+++ b/config/openshift/v4_8_exp/schema.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.)
 
-package v0_2_exp
+package v4_8_exp
 
 import (
 	fcos "github.com/coreos/fcct/config/fcos/v1_4_exp"

--- a/config/openshift/v4_8_exp/translate.go
+++ b/config/openshift/v4_8_exp/translate.go
@@ -16,11 +16,74 @@ package v4_8_exp
 
 import (
 	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/config/openshift/v4_8_exp/result"
 	cutil "github.com/coreos/fcct/config/util"
+	"github.com/coreos/fcct/translate"
 
 	"github.com/coreos/ignition/v2/config/v3_2/types"
+	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 )
+
+// ToMachineConfig4_8Unvalidated translates the config to a MachineConfig.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToMachineConfig4_8Unvalidated(options common.TranslateOptions) (result.MachineConfig, translate.TranslationSet, report.Report) {
+	cfg, ts, r := c.Config.ToIgn3_2Unvalidated(options)
+	if r.IsFatal() {
+		return result.MachineConfig{}, ts, r
+	}
+
+	// wrap
+	ts = ts.PrefixPaths(path.New("yaml"), path.New("json", "spec", "config"))
+	mc := result.MachineConfig{
+		ApiVersion: "machineconfiguration.openshift.io/v1",
+		Kind:       "MachineConfig",
+		Metadata: result.Metadata{
+			Name:   c.Metadata.Name,
+			Labels: make(map[string]string),
+		},
+		Spec: result.Spec{
+			Config: cfg,
+		},
+	}
+	ts.AddTranslation(path.New("yaml", "version"), path.New("json", "apiVersion"))
+	ts.AddTranslation(path.New("yaml", "version"), path.New("json", "kind"))
+	ts.AddTranslation(path.New("yaml", "metadata"), path.New("json", "metadata"))
+	ts.AddTranslation(path.New("yaml", "metadata", "name"), path.New("json", "metadata", "name"))
+	ts.AddTranslation(path.New("yaml", "version"), path.New("json", "spec"))
+	ts.AddTranslation(path.New("yaml"), path.New("json", "spec", "config"))
+	for k, v := range c.Metadata.Labels {
+		mc.Metadata.Labels[k] = v
+		ts.AddTranslation(path.New("yaml", "metadata", "labels", k), path.New("json", "metadata", "labels", k))
+	}
+	if len(mc.Metadata.Labels) > 0 {
+		ts.AddTranslation(path.New("yaml", "metadata", "labels"), path.New("json", "metadata", "labels"))
+	}
+
+	return mc, ts, r
+}
+
+// ToMachineConfig4_8 translates the config to a MachineConfig.  It returns a
+// report of any errors or warnings in the source and resultant config.  If
+// the report has fatal errors or it encounters other problems translating,
+// an error is returned.
+func (c Config) ToMachineConfig4_8(options common.TranslateOptions) (result.MachineConfig, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToMachineConfig4_8Unvalidated", options)
+	return cfg.(result.MachineConfig), r, err
+}
+
+// ToIgn3_2Unvalidated translates the config to an Ignition config.  It also
+// returns the set of translations it did so paths in the resultant config
+// can be tracked back to their source in the source config.  No config
+// validation is performed on input or output.
+func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
+	mc, ts, r := c.ToMachineConfig4_8Unvalidated(options)
+	cfg := mc.Spec.Config
+	ts = ts.Descend(path.New("json", "spec", "config"))
+	return cfg, ts, r
+}
 
 // ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
@@ -31,9 +94,13 @@ func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.
 	return cfg.(types.Config), r, err
 }
 
-// ToIgn3_2Bytes translates from a v4.8 occ to a v3.2.0 Ignition config. It returns a report of any errors or
+// ToConfigBytes translates from a v4.8 occ to a v4.8 MachineConfig or a v3.2.0 Ignition config. It returns a report of any errors or
 // warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
 // translating, an error is returned.
-func ToIgn3_2Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
-	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
+func ToConfigBytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	if options.Raw {
+		return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
+	} else {
+		return cutil.TranslateBytesYAML(input, &Config{}, "ToMachineConfig4_8", options)
+	}
 }

--- a/config/openshift/v4_8_exp/translate.go
+++ b/config/openshift/v4_8_exp/translate.go
@@ -18,22 +18,22 @@ import (
 	"github.com/coreos/fcct/config/common"
 	cutil "github.com/coreos/fcct/config/util"
 
-	"github.com/coreos/ignition/v2/config/v3_3_experimental/types"
+	"github.com/coreos/ignition/v2/config/v3_2/types"
 	"github.com/coreos/vcontext/report"
 )
 
-// ToIgn3_3 translates the config to an Ignition config.  It returns a
+// ToIgn3_2 translates the config to an Ignition config.  It returns a
 // report of any errors or warnings in the source and resultant config.  If
 // the report has fatal errors or it encounters other problems translating,
 // an error is returned.
-func (c Config) ToIgn3_3(options common.TranslateOptions) (types.Config, report.Report, error) {
-	cfg, r, err := cutil.Translate(c, "ToIgn3_3Unvalidated", options)
+func (c Config) ToIgn3_2(options common.TranslateOptions) (types.Config, report.Report, error) {
+	cfg, r, err := cutil.Translate(c, "ToIgn3_2Unvalidated", options)
 	return cfg.(types.Config), r, err
 }
 
-// ToIgn3_3Bytes translates from a v0.2 rcc to a v3.3.0 Ignition config. It returns a report of any errors or
+// ToIgn3_2Bytes translates from a v4.8 occ to a v3.2.0 Ignition config. It returns a report of any errors or
 // warnings in the source and resultant config. If the report has fatal errors or it encounters other problems
 // translating, an error is returned.
-func ToIgn3_3Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
-	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_3", options)
+func ToIgn3_2Bytes(input []byte, options common.TranslateBytesOptions) ([]byte, report.Report, error) {
+	return cutil.TranslateBytes(input, &Config{}, "ToIgn3_2", options)
 }

--- a/config/openshift/v4_8_exp/translate.go
+++ b/config/openshift/v4_8_exp/translate.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.)
 
-package v0_2_exp
+package v4_8_exp
 
 import (
 	"github.com/coreos/fcct/config/common"

--- a/config/openshift/v4_8_exp/validate.go
+++ b/config/openshift/v4_8_exp/validate.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Red Hat, Inc
+// Copyright 2021 Red Hat, Inc
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,15 +15,15 @@
 package v4_8_exp
 
 import (
-	fcos "github.com/coreos/fcct/config/fcos/v1_3"
+	"github.com/coreos/fcct/config/common"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
 )
 
-type Config struct {
-	fcos.Config `yaml:",inline"`
-	Metadata    Metadata `yaml:"metadata"`
-}
-
-type Metadata struct {
-	Name   string            `yaml:"name"`
-	Labels map[string]string `yaml:"labels,omitempty"`
+func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
+	if m.Name == "" {
+		r.AddOnError(c.Append("name"), common.ErrNameRequired)
+	}
+	return
 }

--- a/config/openshift/v4_8_exp/validate_test.go
+++ b/config/openshift/v4_8_exp/validate_test.go
@@ -159,10 +159,14 @@ func TestReportCorrelation(t *testing.T) {
 	}
 
 	for i, test := range tests {
-		_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
-		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
-		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
-		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
-		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+		for _, raw := range []bool{false, true} {
+			_, r, _ := ToConfigBytes([]byte(test.in), common.TranslateBytesOptions{
+				Raw: raw,
+			})
+			assert.Len(t, r.Entries, 1, "#%d: unexpected report length, raw %v", i, raw)
+			assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error, raw %v", i, raw)
+			assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil, raw %v", i, raw)
+			assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line, raw %v", i, raw)
+		}
 	}
 }

--- a/config/openshift/v4_8_exp/validate_test.go
+++ b/config/openshift/v4_8_exp/validate_test.go
@@ -1,0 +1,120 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v4_8_exp
+
+import (
+	"testing"
+
+	"github.com/coreos/fcct/config/common"
+
+	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestReportCorrelation tests that errors are correctly correlated to their source lines
+func TestReportCorrelation(t *testing.T) {
+	tests := []struct {
+		in      string
+		message string
+		line    int64
+	}{
+		// FCCT unused key check
+		{
+			`storage:
+                           files:
+                           - path: /z
+                             q: z`,
+			"Unused key q",
+			4,
+		},
+		// FCCT YAML validation error
+		{
+			`storage:
+                           files:
+                           - path: /z
+                             contents:
+                               source: https://example.com
+                               inline: z`,
+			common.ErrTooManyResourceSources.Error(),
+			5,
+		},
+		// FCCT YAML validation warning
+		{
+			`storage:
+                           files:
+                           - path: /z
+                             mode: 644`,
+			common.ErrDecimalMode.Error(),
+			4,
+		},
+		// FCCT translation error
+		{
+			`storage:
+                           files:
+                           - path: /z
+                             contents:
+                               local: z`,
+			common.ErrNoFilesDir.Error(),
+			5,
+		},
+		// Ignition validation error, leaf node
+		{
+			`storage:
+                           files:
+                           - path: z`,
+			errors.ErrPathRelative.Error(),
+			3,
+		},
+		// Ignition validation error, partition
+		{
+			`storage:
+                           disks:
+                           - device: /dev/z
+                             partitions:
+                               - start_mib: 5`,
+			errors.ErrNeedLabelOrNumber.Error(),
+			5,
+		},
+		// Ignition validation error, partition list
+		{
+			`storage:
+                           disks:
+                           - device: /dev/z
+                             partitions:
+                               - number: 1
+                                 should_exist: false
+                               - label: z`,
+			errors.ErrZeroesWithShouldNotExist.Error(),
+			5,
+		},
+		// Ignition duplicate key check, paths
+		{
+			`storage:
+                           files:
+                           - path: /z
+                           - path: /z`,
+			errors.ErrDuplicate.Error(),
+			4,
+		},
+	}
+
+	for i, test := range tests {
+		_, r, _ := ToIgn3_2Bytes([]byte(test.in), common.TranslateBytesOptions{})
+		assert.Len(t, r.Entries, 1, "#%d: unexpected report length", i)
+		assert.Equal(t, test.message, r.Entries[0].Message, "#%d: bad error", i)
+		assert.NotNil(t, r.Entries[0].Marker.StartP, "#%d: marker start is nil", i)
+		assert.Equal(t, test.line, r.Entries[0].Marker.StartP.Line, "#%d: incorrect error line", i)
+	}
+}

--- a/docs/config-openshift-v4_8-exp.md
+++ b/docs/config-openshift-v4_8-exp.md
@@ -13,6 +13,9 @@ The OpenShift configuration is a YAML document conforming to the following speci
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
 * **version** (string): the semantic version of the spec for this document. This document is for version `4.8.0-experimental` and generates Ignition configs with version `3.2.0`.
+* **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
+  * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
+  * **_labels_** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.
@@ -202,6 +205,8 @@ The OpenShift configuration is a YAML document conforming to the following speci
   * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
     * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
 
+[k8s-names]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
+[k8s-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/
 [part-types]: http://en.wikipedia.org/wiki/GUID_Partition_Table#Partition_type_GUIDs
 [rfc2397]: https://tools.ietf.org/html/rfc2397
 [systemd-escape]: https://www.freedesktop.org/software/systemd/man/systemd-escape.html

--- a/docs/config-openshift-v4_8-exp.md
+++ b/docs/config-openshift-v4_8-exp.md
@@ -1,18 +1,18 @@
 ---
 layout: default
-title: RHEL CoreOS v0.2.0-experimental
+title: OpenShift v4.8.0-experimental
 parent: Configuration specifications
 nav_order: 100
 ---
 
-# RHEL CoreOS Specification v0.2.0-experimental
+# OpenShift Specification v4.8.0-experimental
 
 **Note: This configuration is experimental and has not been stabilized. It is subject to change without warning or announcement.**
 
-The RHEL CoreOS configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
+The OpenShift configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
-* **version** (string): the semantic version of the spec for this document. This document is for version `0.2.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `4.8.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.

--- a/docs/config-openshift-v4_8-exp.md
+++ b/docs/config-openshift-v4_8-exp.md
@@ -12,7 +12,7 @@ nav_order: 100
 The OpenShift configuration is a YAML document conforming to the following specification, with **_italicized_** entries being optional:
 
 * **variant** (string): used to differentiate configs for different operating systems. Must be `rhcos` for this specification.
-* **version** (string): the semantic version of the spec for this document. This document is for version `4.8.0-experimental` and generates Ignition configs with version `3.3.0-experimental`.
+* **version** (string): the semantic version of the spec for this document. This document is for version `4.8.0-experimental` and generates Ignition configs with version `3.2.0`.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -43,5 +43,5 @@ Each version of the FCC specification corresponds to a version of the Ignition s
 | `fcos`      | 1.2.0              | 3.2.0              |
 | `fcos`      | 1.3.0              | 3.2.0              |
 | `fcos`      | 1.4.0-experimental | 3.3.0-experimental |
-| `openshift` | 4.8.0-experimental | 3.3.0-experimental |
+| `openshift` | 4.8.0-experimental | 3.2.0              |
 | `rhcos`     | 0.1.0              | 3.2.0              |

--- a/docs/specs.md
+++ b/docs/specs.md
@@ -29,8 +29,8 @@ Do not use **experimental** specifications for anything beyond **development and
 
 - Fedora CoreOS (`fcos`)
   - [v1.4.0-experimental](config-fcos-v1_4-exp.md)
-- RHEL CoreOS (`rhcos`)
-  - [v0.2.0-experimental](config-rhcos-v0_2-exp.md)
+- OpenShift (`openshift`)
+  - [v4.8.0-experimental](config-openshift-v4_8-exp.md)
 
 ## FCC specifications and Ignition specifications
 
@@ -43,5 +43,5 @@ Each version of the FCC specification corresponds to a version of the Ignition s
 | `fcos`      | 1.2.0              | 3.2.0              |
 | `fcos`      | 1.3.0              | 3.2.0              |
 | `fcos`      | 1.4.0-experimental | 3.3.0-experimental |
+| `openshift` | 4.8.0-experimental | 3.3.0-experimental |
 | `rhcos`     | 0.1.0              | 3.2.0              |
-| `rhcos`     | 0.2.0-experimental | 3.3.0-experimental |

--- a/internal/main.go
+++ b/internal/main.go
@@ -45,6 +45,7 @@ func main() {
 	pflag.Lookup("debug").Hidden = true
 	pflag.BoolVarP(&options.Strict, "strict", "s", false, "fail on any warning")
 	pflag.BoolVarP(&options.Pretty, "pretty", "p", false, "output formatted json")
+	pflag.BoolVarP(&options.Raw, "raw", "r", false, "never wrap in a MachineConfig; force Ignition output")
 	pflag.StringVar(&input, "input", "", "read from input file instead of stdin")
 	pflag.Lookup("input").Deprecated = "specify filename directly on command line"
 	pflag.Lookup("input").Hidden = true

--- a/translate/set.go
+++ b/translate/set.go
@@ -142,6 +142,27 @@ func (ts TranslationSet) PrefixPaths(fromPrefix, toPrefix path.ContextPath) Tran
 	return ret
 }
 
+// Descend returns the subtree of translations rooted at the specified To path.
+func (ts TranslationSet) Descend(to path.ContextPath) TranslationSet {
+	ret := NewTranslationSet(ts.FromTag, ts.ToTag)
+OUTER:
+	for _, tr := range ts.Set {
+		if len(tr.To.Path) < len(to.Path) {
+			// can't be in the requested subtree; skip
+			continue
+		}
+		for i, e := range to.Path {
+			if tr.To.Path[i] != e {
+				// not in the requested subtree; skip
+				continue OUTER
+			}
+		}
+		subtreePath := path.New(tr.To.Tag, tr.To.Path[len(to.Path):]...)
+		ret.AddTranslation(tr.From, subtreePath)
+	}
+	return ret
+}
+
 // DebugVerifyCoverage recursively checks whether every non-zero field in v
 // has a translation.  If translations are missing, it returns a multi-line
 // error listing them.

--- a/translate/util.go
+++ b/translate/util.go
@@ -81,6 +81,19 @@ func getAllPaths(v reflect.Value, tag string, includeZeroFields bool) []path.Con
 			}
 		}
 		return ret
+	case k == reflect.Map:
+		// we don't have these in FCCs or Ignition configs, but
+		// we need to support validating translations of
+		// metadata.labels in MachineConfig output
+		ret := []path.ContextPath{}
+		iter := v.MapRange()
+		for iter.Next() {
+			// for struct, pointer to struct, etc., add any children
+			ret = append(ret, prefixPaths(getAllPaths(iter.Value(), tag, includeZeroFields), iter.Key())...)
+			// add map entry
+			ret = append(ret, path.New(tag, iter.Key()))
+		}
+		return ret
 	default:
 		panic("Encountered unexpected type. This is a bug, please file a report")
 	}

--- a/translate/util.go
+++ b/translate/util.go
@@ -82,7 +82,7 @@ func getAllPaths(v reflect.Value, tag string, includeZeroFields bool) []path.Con
 		}
 		return ret
 	default:
-		panic("Encountered types that are not the same when they should be. This is a bug, please file a report")
+		panic("Encountered unexpected type. This is a bug, please file a report")
 	}
 }
 


### PR DESCRIPTION
Rename `rhcos`/`0.2.0-experimental` to `openshift`/`4.8.0-experimental`.  Use `openshift` as the variant name instead of `rhcos` because RHCOS is an implementation detail of OpenShift, and also would leave OKD in an awkward position.  By reusing OpenShift version numbers, we're setting ourselves up to eventually violate semver, but it doesn't seem reasonable to create a novel set of user-facing version numbers that isn't connected to anything else.

Have the new spec generate MachineConfigs by default, but also accept a new `-r/--raw/Raw` option to generate an Ignition config.  This allows FCCT to be used for sugar (e.g. for [boot disk mirroring](https://docs.openshift.com/container-platform/4.7/installing/install_config/installing-customizing.html#installation-special-config-mirrored-disk_installing-customizing)) and validation (e.g. rejecting users other than `core`) without modifying the pointer config, and without requiring MCO changes.  We'll have a new spec version for each OpenShift release, so we'll also have the ability to change the output format as needed by future MCO releases.

As an implementation detail, ship a simplified copy of the [MachineConfig structs](https://github.com/openshift/machine-config-operator/blob/82868e63176fee2bc806c1deb308ed1fc8965d84/pkg/apis/machineconfiguration.openshift.io/v1/types.go) so we don't have to pull in a bunch of k8s code as dependencies.  (And to avoid a circular dependency with the MCO.)

Sample `input.occ`:

```yaml
variant: openshift
version: 4.8.0-experimental
metadata:
  name: create-etc-sample
  labels:
    machineconfiguration.openshift.io/role: worker
storage:
  files:
    - path: /etc/sample
      contents:
        inline: hello world
```

`fcct input.occ` produces:

```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  labels:
    machineconfiguration.openshift.io/role: worker
  name: create-etc-sample
spec:
  config:
    ignition:
      version: 3.2.0
    storage:
      files:
      - contents:
          source: data:,hello%20world
        path: /etc/sample
```

And `fcct --pretty --raw input.occ` produces:

```json
{
  "ignition": {
    "version": "3.2.0"
  },
  "storage": {
    "files": [
      {
        "path": "/etc/sample",
        "contents": {
          "source": "data:,hello%20world"
        }
      }
    ]
  }
}
```

@yuqi-zhang, @sinnykumari, and/or other folks from the MCO team, wdyt?