### PR TITLE
openshift/v4_8_exp: support top-level MachineConfig fields

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -48,6 +48,7 @@ var (
 	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
 
 	// MachineConfigs
-	ErrNameRequired = errors.New("metadata.name is required")
-	ErrRoleRequired = errors.New("machineconfiguration.openshift.io/role label is required")
+	ErrNameRequired      = errors.New("metadata.name is required")
+	ErrRoleRequired      = errors.New("machineconfiguration.openshift.io/role label is required")
+	ErrInvalidKernelType = errors.New("must be empty, \"default\", or \"realtime\"")
 )

--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -48,6 +48,7 @@ var (
 	ErrTooFewMirrorDevices     = errors.New("mirroring requires at least two devices")
 
 	// MachineConfigs
+	ErrFieldElided       = errors.New("field ignored in raw mode")
 	ErrNameRequired      = errors.New("metadata.name is required")
 	ErrRoleRequired      = errors.New("machineconfiguration.openshift.io/role label is required")
 	ErrInvalidKernelType = errors.New("must be empty, \"default\", or \"realtime\"")

--- a/config/openshift/v4_8_exp/result/schema.go
+++ b/config/openshift/v4_8_exp/result/schema.go
@@ -35,5 +35,9 @@ type Metadata struct {
 }
 
 type Spec struct {
-	Config types.Config `json:"config"`
+	Config          types.Config `json:"config"`
+	KernelArguments []string     `json:"kernelArguments,omitempty"`
+	Extensions      []string     `json:"extensions,omitempty"`
+	FIPS            *bool        `json:"fips,omitempty"`
+	KernelType      *string      `json:"kernelType,omitempty"`
 }

--- a/config/openshift/v4_8_exp/schema.go
+++ b/config/openshift/v4_8_exp/schema.go
@@ -22,10 +22,18 @@ const ROLE_LABEL_KEY = "machineconfiguration.openshift.io/role"
 
 type Config struct {
 	fcos.Config `yaml:",inline"`
-	Metadata    Metadata `yaml:"metadata"`
+	Metadata    Metadata  `yaml:"metadata"`
+	OpenShift   OpenShift `yaml:"openshift"`
 }
 
 type Metadata struct {
 	Name   string            `yaml:"name"`
 	Labels map[string]string `yaml:"labels,omitempty"`
+}
+
+type OpenShift struct {
+	KernelArguments []string `yaml:"kernel_arguments"`
+	Extensions      []string `yaml:"extensions"`
+	FIPS            *bool    `yaml:"fips"`
+	KernelType      *string  `yaml:"kernel_type"`
 }

--- a/config/openshift/v4_8_exp/translate.go
+++ b/config/openshift/v4_8_exp/translate.go
@@ -92,6 +92,14 @@ func (c Config) ToMachineConfig4_8(options common.TranslateOptions) (result.Mach
 func (c Config) ToIgn3_2Unvalidated(options common.TranslateOptions) (types.Config, translate.TranslationSet, report.Report) {
 	mc, ts, r := c.ToMachineConfig4_8Unvalidated(options)
 	cfg := mc.Spec.Config
+
+	// report warnings if there are any non-empty fields in Spec (other
+	// than the Ignition config itself) that we're ignoring
+	mc.Spec.Config = types.Config{}
+	warnings := translate.PrefixReport(cutil.CheckForElidedFields(mc.Spec), "spec")
+	// translate from json space into yaml space
+	r.Merge(cutil.TranslateReportPaths(warnings, ts))
+
 	ts = ts.Descend(path.New("json", "spec", "config"))
 	return cfg, ts, r
 }

--- a/config/openshift/v4_8_exp/translate.go
+++ b/config/openshift/v4_8_exp/translate.go
@@ -62,6 +62,17 @@ func (c Config) ToMachineConfig4_8Unvalidated(options common.TranslateOptions) (
 		ts.AddTranslation(path.New("yaml", "metadata", "labels"), path.New("json", "metadata", "labels"))
 	}
 
+	// translate OpenShift fields
+	tr := translate.NewTranslator("yaml", "json", options)
+	from := &c.OpenShift
+	to := &mc.Spec
+	ts2, r2 := translate.Prefixed(tr, "extensions", &from.Extensions, &to.Extensions)
+	translate.MergeP(tr, ts2, &r2, "fips", &from.FIPS, &to.FIPS)
+	translate.MergeP2(tr, ts2, &r2, "kernel_arguments", &from.KernelArguments, "kernelArguments", &to.KernelArguments)
+	translate.MergeP2(tr, ts2, &r2, "kernel_type", &from.KernelType, "kernelType", &to.KernelType)
+	ts.MergeP2("openshift", "spec", ts2)
+	r.Merge(r2)
+
 	return mc, ts, r
 }
 

--- a/config/openshift/v4_8_exp/translate_test.go
+++ b/config/openshift/v4_8_exp/translate_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Red Hat, Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.)
+
+package v4_8_exp
+
+import (
+	"testing"
+
+	"github.com/coreos/fcct/config/common"
+
+	"github.com/coreos/ignition/v2/config/util"
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
+)
+
+// TestElidedFieldWarning tests that we warn when transpiling fields to an
+// Ignition config that can't be represented in an Ignition config.
+func TestElidedFieldWarning(t *testing.T) {
+	in := Config{
+		Metadata: Metadata{
+			Name: "z",
+		},
+		OpenShift: OpenShift{
+			KernelArguments: []string{"a", "b"},
+			FIPS:            util.BoolToPtr(true),
+			KernelType:      util.StrToPtr("realtime"),
+		},
+	}
+
+	var expected report.Report
+	expected.AddOnWarn(path.New("yaml", "openshift", "kernel_arguments"), common.ErrFieldElided)
+	expected.AddOnWarn(path.New("yaml", "openshift", "fips"), common.ErrFieldElided)
+	expected.AddOnWarn(path.New("yaml", "openshift", "kernel_type"), common.ErrFieldElided)
+
+	_, _, r := in.ToIgn3_2Unvalidated(common.TranslateOptions{})
+	assert.Equal(t, expected, r, "report mismatch")
+}

--- a/config/openshift/v4_8_exp/validate.go
+++ b/config/openshift/v4_8_exp/validate.go
@@ -30,3 +30,14 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 	}
 	return
 }
+
+func (os OpenShift) Validate(c path.ContextPath) (r report.Report) {
+	if os.KernelType != nil {
+		switch *os.KernelType {
+		case "", "default", "realtime":
+		default:
+			r.AddOnError(c.Append("kernel_type"), common.ErrInvalidKernelType)
+		}
+	}
+	return
+}

--- a/config/openshift/v4_8_exp/validate_test.go
+++ b/config/openshift/v4_8_exp/validate_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/coreos/fcct/config/common"
 
 	"github.com/coreos/ignition/v2/config/shared/errors"
+	"github.com/coreos/ignition/v2/config/util"
 	"github.com/coreos/vcontext/path"
 	"github.com/coreos/vcontext/report"
 	"github.com/stretchr/testify/assert"
@@ -59,6 +60,36 @@ func TestValidateMetadata(t *testing.T) {
 			},
 			common.ErrRoleRequired,
 			path.New("yaml", "labels", ROLE_LABEL_KEY),
+		},
+	}
+
+	for i, test := range tests {
+		actual := test.in.Validate(path.New("yaml"))
+		expected := report.Report{}
+		expected.AddOnError(test.errPath, test.out)
+		assert.Equal(t, expected, actual, "#%d: bad report", i)
+	}
+}
+
+func TestValidateOpenShift(t *testing.T) {
+	tests := []struct {
+		in      OpenShift
+		out     error
+		errPath path.ContextPath
+	}{
+		// empty struct
+		{
+			OpenShift{},
+			nil,
+			path.New("yaml"),
+		},
+		// bad kernel type
+		{
+			OpenShift{
+				KernelType: util.StrToPtr("hurd"),
+			},
+			common.ErrInvalidKernelType,
+			path.New("yaml", "kernel_type"),
 		},
 	}
 

--- a/config/util/util_test.go
+++ b/config/util/util_test.go
@@ -16,6 +16,13 @@ package util
 
 import (
 	"testing"
+
+	"github.com/coreos/fcct/config/common"
+	"github.com/coreos/fcct/translate"
+
+	"github.com/coreos/vcontext/path"
+	"github.com/coreos/vcontext/report"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestSnake(t *testing.T) {
@@ -47,4 +54,24 @@ func TestSnake(t *testing.T) {
 			t.Errorf("#%d: expected %q got %q", i, test.out, snake(test.in))
 		}
 	}
+}
+
+func TestTranslateReportPaths(t *testing.T) {
+	ts := translate.NewTranslationSet("yaml", "json")
+	ts.AddTranslation(path.New("yaml", "a", "b", "c"), path.New("json", "d", "e", "f"))
+	makeReport := func(source bool) report.Report {
+		var r report.Report
+		var p path.ContextPath
+		if source {
+			p = path.New("yaml", "a", "b", "c")
+		} else {
+			p = path.New("json", "d", "e", "f")
+		}
+		r.AddOnError(p, common.ErrDecimalMode)
+		return r
+	}
+	r := makeReport(false)
+	r2 := TranslateReportPaths(r, ts)
+	assert.Equal(t, makeReport(false), r, "TranslateReportPaths changed original report")
+	assert.Equal(t, makeReport(true), r2, "TranslateReportPaths returned incorrect report")
 }

--- a/docs/config-openshift-v4_8-exp.md
+++ b/docs/config-openshift-v4_8-exp.md
@@ -204,6 +204,11 @@ The OpenShift configuration is a YAML document conforming to the following speci
     * **_threshold_** (int): sets the minimum number of pieces required to decrypt the device.
   * **_mirror_** (object): describes mirroring of the boot disk for fault tolerance.
     * **_devices_** (list of strings): the list of whole-disk devices (not partitions) to include in the disk array, referenced by their absolute path. At least two devices must be specified.
+* **_openshift_** (object): describes miscellaneous OpenShift configuration. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
+  * **_kernel_type_** (string): which kernel to use on the node. Must be `default` or `realtime`.
+  * **_kernel_arguments_** (list of strings): arguments to be added to the kernel command line.
+  * **_extensions_** (list of strings): RHCOS extensions to be installed on the node.
+  * **_fips_** (bool): whether or not to enable FIPS 140-2 compatibility. If omitted, defaults to false.
 
 [k8s-names]: https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#names
 [k8s-labels]: https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/

--- a/translate/set.go
+++ b/translate/set.go
@@ -121,9 +121,15 @@ func (ts TranslationSet) Merge(from TranslationSet) {
 	}
 }
 
-// MergeP is like Merge, but first it calls Prefix on the set being merged in.
+// MergeP is like Merge, but it adds a prefix to the set being merged in.
 func (ts TranslationSet) MergeP(prefix interface{}, from TranslationSet) {
-	from = from.Prefix(prefix)
+	ts.MergeP2(prefix, prefix, from)
+}
+
+// MergeP2 is like Merge, but it adds distinct prefixes to each side of the
+// set being merged in.
+func (ts TranslationSet) MergeP2(fromPrefix interface{}, toPrefix interface{}, from TranslationSet) {
+	from = from.PrefixPaths(path.New(from.FromTag, fromPrefix), path.New(from.ToTag, toPrefix))
 	ts.Merge(from)
 }
 

--- a/translate/util.go
+++ b/translate/util.go
@@ -100,7 +100,7 @@ func getAllPaths(v reflect.Value, tag string, includeZeroFields bool) []path.Con
 }
 
 // Return a copy of the report, with the context paths prefixed by prefix.
-func prefixReport(r report.Report, prefix interface{}) report.Report {
+func PrefixReport(r report.Report, prefix interface{}) report.Report {
 	var ret report.Report
 	ret.Merge(r)
 	for i := range ret.Entries {
@@ -114,7 +114,7 @@ func prefixReport(r report.Report, prefix interface{}) report.Report {
 // TranslationSet and Report.
 func Prefixed(tr Translator, prefix interface{}, from interface{}, to interface{}) (TranslationSet, report.Report) {
 	tm, r := tr.Translate(from, to)
-	return tm.Prefix(prefix), prefixReport(r, prefix)
+	return tm.Prefix(prefix), PrefixReport(r, prefix)
 }
 
 // Utility function to run a translation and merge the result, with the
@@ -129,5 +129,5 @@ func MergeP2(tr Translator, tm TranslationSet, r *report.Report, fromPrefix inte
 	translations, report := tr.Translate(from, to)
 	tm.MergeP2(fromPrefix, toPrefix, translations)
 	// translation report paths are on the from side
-	r.Merge(prefixReport(report, fromPrefix))
+	r.Merge(PrefixReport(report, fromPrefix))
 }

--- a/translate/util.go
+++ b/translate/util.go
@@ -120,7 +120,14 @@ func Prefixed(tr Translator, prefix interface{}, from interface{}, to interface{
 // Utility function to run a translation and merge the result, with the
 // specified prefix, into the specified TranslationSet and Report.
 func MergeP(tr Translator, tm TranslationSet, r *report.Report, prefix interface{}, from interface{}, to interface{}) {
+	MergeP2(tr, tm, r, prefix, from, prefix, to)
+}
+
+// Utility function to run a translation and merge the result, with the
+// specified prefixes, into the specified TranslationSet and Report.
+func MergeP2(tr Translator, tm TranslationSet, r *report.Report, fromPrefix interface{}, from interface{}, toPrefix interface{}, to interface{}) {
 	translations, report := tr.Translate(from, to)
-	tm.MergeP(prefix, translations)
-	r.Merge(prefixReport(report, prefix))
+	tm.MergeP2(fromPrefix, toPrefix, translations)
+	// translation report paths are on the from side
+	r.Merge(prefixReport(report, fromPrefix))
 }


### PR DESCRIPTION
Add an `openshift` section containing the fields at the top level of a MachineConfig:

```yaml
variant: openshift
version: 4.8.0-experimental
metadata:
  name: z
openshift:
  kernel_arguments: [a, b, c]
  extensions: [d, e]
  fips: true
  kernel_type: realtime
```

Output:

```yaml
apiVersion: machineconfiguration.openshift.io/v1
kind: MachineConfig
metadata:
  name: z
spec:
  config:
    ignition:
      version: 3.2.0
  extensions:
  - d
  - e
  fips: true
  kernelArguments:
  - a
  - b
  - c
  kernelType: realtime
```

Report warnings in `--raw` mode if any such fields are specified, since we can't represent them directly in an Ignition config.

Followup to #212.

cc @sinnykumari 