### PR TITLE
openshift/v4_8_exp: require machineconfiguration.openshift.io/role

### DIFF
--- a/config/common/errors.go
+++ b/config/common/errors.go
@@ -49,4 +49,5 @@ var (
 
 	// MachineConfigs
 	ErrNameRequired = errors.New("metadata.name is required")
+	ErrRoleRequired = errors.New("machineconfiguration.openshift.io/role label is required")
 )

--- a/config/openshift/v4_8_exp/schema.go
+++ b/config/openshift/v4_8_exp/schema.go
@@ -18,6 +18,8 @@ import (
 	fcos "github.com/coreos/fcct/config/fcos/v1_3"
 )
 
+const ROLE_LABEL_KEY = "machineconfiguration.openshift.io/role"
+
 type Config struct {
 	fcos.Config `yaml:",inline"`
 	Metadata    Metadata `yaml:"metadata"`

--- a/config/openshift/v4_8_exp/validate.go
+++ b/config/openshift/v4_8_exp/validate.go
@@ -25,5 +25,8 @@ func (m Metadata) Validate(c path.ContextPath) (r report.Report) {
 	if m.Name == "" {
 		r.AddOnError(c.Append("name"), common.ErrNameRequired)
 	}
+	if m.Labels[ROLE_LABEL_KEY] == "" {
+		r.AddOnError(c.Append("labels", ROLE_LABEL_KEY), common.ErrRoleRequired)
+	}
 	return
 }

--- a/docs/config-openshift-v4_8-exp.md
+++ b/docs/config-openshift-v4_8-exp.md
@@ -15,7 +15,7 @@ The OpenShift configuration is a YAML document conforming to the following speci
 * **version** (string): the semantic version of the spec for this document. This document is for version `4.8.0-experimental` and generates Ignition configs with version `3.2.0`.
 * **metadata** (object): metadata about the generated MachineConfig resource. Respected when rendering to a MachineConfig, ignored when rendering directly to an Ignition config.
   * **name** (string): a unique [name][k8s-names] for this MachineConfig resource.
-  * **_labels_** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource.
+  * **labels** (object): string key/value pairs to apply as [Kubernetes labels][k8s-labels] to this MachineConfig resource. `machineconfiguration.openshift.io/role` is required.
 * **ignition** (object): metadata about the configuration itself.
   * **_config_** (objects): options related to the configuration.
     * **_merge_** (list of objects): a list of the configs to be merged to the current config.


### PR DESCRIPTION
Require a non-empty `machineconfiguration.openshift.io/role` label in `metadata.labels`.

Addresses https://github.com/coreos/fcct/pull/214#issuecomment-802960498.  cc @sinnykumari 