### PR TITLE
base/*: use MergeP() everywhere; drop AddIdentity()

### DIFF
--- a/base/v0_1/translate.go
+++ b/base/v0_1/translate.go
@@ -67,19 +67,17 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
 	translate.MergeP(tr, tm, &r, "append", &from.Append, &to.Append)
 	translate.MergeP(tr, tm, &r, "contents", &from.Contents, &to.Contents)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
 func translateFileContents(from FileContents, options common.TranslateOptions) (to types.FileContents, tm translate.TranslationSet, r report.Report) {
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
-	to.Source = from.Source
-	to.Compression = from.Compression
-	tm.AddIdentity("source", "compression")
+	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
+	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 	if from.Inline != nil {
 		src := (&url.URL{
 			Scheme: "data",
@@ -95,10 +93,9 @@ func translateDirectory(from Directory, options common.TranslateOptions) (to typ
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -106,10 +103,9 @@ func translateLink(from Link, options common.TranslateOptions) (to types.Link, t
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Target = from.Target
-	to.Hard = from.Hard
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	tm.AddIdentity("target", "hard", "overwrite", "path")
+	translate.MergeP(tr, tm, &r, "target", &from.Target, &to.Target)
+	translate.MergeP(tr, tm, &r, "hard", &from.Hard, &to.Hard)
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
 	return
 }

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -292,6 +292,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				file.Contents.Compression = util.StrToPtr("gzip")
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents", "compression"))
 			}
+			ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents"))
 			if file.Mode == nil {
 				mode := 0644
 				if info.Mode()&0111 != 0 {

--- a/base/v0_2/translate.go
+++ b/base/v0_2/translate.go
@@ -104,10 +104,9 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
 	translate.MergeP(tr, tm, &r, "append", &from.Append, &to.Append)
 	translate.MergeP(tr, tm, &r, "contents", &from.Contents, &to.Contents)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -115,9 +114,8 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
 	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
-	to.Source = from.Source
-	to.Compression = from.Compression
-	tm.AddIdentity("source", "compression")
+	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
+	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 
 	if from.Local != nil {
 		c := path.New("yaml", "local")
@@ -176,10 +174,9 @@ func translateDirectory(from Directory, options common.TranslateOptions) (to typ
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -187,11 +184,10 @@ func translateLink(from Link, options common.TranslateOptions) (to types.Link, t
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Target = from.Target
-	to.Hard = from.Hard
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	tm.AddIdentity("target", "hard", "overwrite", "path")
+	translate.MergeP(tr, tm, &r, "target", &from.Target, &to.Target)
+	translate.MergeP(tr, tm, &r, "hard", &from.Hard, &to.Hard)
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
 	return
 }
 

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -303,6 +303,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				file.Contents.Compression = util.StrToPtr("gzip")
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents", "compression"))
 			}
+			ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents"))
 			if file.Mode == nil {
 				mode := 0644
 				if info.Mode()&0111 != 0 {

--- a/base/v0_3/translate.go
+++ b/base/v0_3/translate.go
@@ -115,10 +115,9 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
 	translate.MergeP(tr, tm, &r, "append", &from.Append, &to.Append)
 	translate.MergeP(tr, tm, &r, "contents", &from.Contents, &to.Contents)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -126,9 +125,8 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
 	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
-	to.Source = from.Source
-	to.Compression = from.Compression
-	tm.AddIdentity("source", "compression")
+	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
+	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 
 	if from.Local != nil {
 		c := path.New("yaml", "local")
@@ -187,10 +185,9 @@ func translateDirectory(from Directory, options common.TranslateOptions) (to typ
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -198,11 +195,10 @@ func translateLink(from Link, options common.TranslateOptions) (to types.Link, t
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Target = from.Target
-	to.Hard = from.Hard
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	tm.AddIdentity("target", "hard", "overwrite", "path")
+	translate.MergeP(tr, tm, &r, "target", &from.Target, &to.Target)
+	translate.MergeP(tr, tm, &r, "hard", &from.Hard, &to.Hard)
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
 	return
 }
 

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -317,6 +317,7 @@ func walkTree(yamlPath path.ContextPath, tree Tree, ts *translate.TranslationSet
 				file.Contents.Compression = util.StrToPtr("gzip")
 				ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents", "compression"))
 			}
+			ts.AddTranslation(yamlPath, path.New("json", "storage", "files", i, "contents"))
 			if file.Mode == nil {
 				mode := 0644
 				if info.Mode()&0111 != 0 {

--- a/base/v0_4_exp/translate.go
+++ b/base/v0_4_exp/translate.go
@@ -129,10 +129,9 @@ func translateFile(from File, options common.TranslateOptions) (to types.File, t
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
 	translate.MergeP(tr, tm, &r, "append", &from.Append, &to.Append)
 	translate.MergeP(tr, tm, &r, "contents", &from.Contents, &to.Contents)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -140,9 +139,8 @@ func translateResource(from Resource, options common.TranslateOptions) (to types
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "verification", &from.Verification, &to.Verification)
 	translate.MergeP(tr, tm, &r, "httpHeaders", &from.HTTPHeaders, &to.HTTPHeaders)
-	to.Source = from.Source
-	to.Compression = from.Compression
-	tm.AddIdentity("source", "compression")
+	translate.MergeP(tr, tm, &r, "source", &from.Source, &to.Source)
+	translate.MergeP(tr, tm, &r, "compression", &from.Compression, &to.Compression)
 
 	if from.Local != nil {
 		c := path.New("yaml", "local")
@@ -201,10 +199,9 @@ func translateDirectory(from Directory, options common.TranslateOptions) (to typ
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	to.Mode = from.Mode
-	tm.AddIdentity("overwrite", "path", "mode")
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
+	translate.MergeP(tr, tm, &r, "mode", &from.Mode, &to.Mode)
 	return
 }
 
@@ -212,11 +209,10 @@ func translateLink(from Link, options common.TranslateOptions) (to types.Link, t
 	tr := translate.NewTranslator("yaml", "json", options)
 	tm, r = translate.Prefixed(tr, "group", &from.Group, &to.Group)
 	translate.MergeP(tr, tm, &r, "user", &from.User, &to.User)
-	to.Target = from.Target
-	to.Hard = from.Hard
-	to.Overwrite = from.Overwrite
-	to.Path = from.Path
-	tm.AddIdentity("target", "hard", "overwrite", "path")
+	translate.MergeP(tr, tm, &r, "target", &from.Target, &to.Target)
+	translate.MergeP(tr, tm, &r, "hard", &from.Hard, &to.Hard)
+	translate.MergeP(tr, tm, &r, "overwrite", &from.Overwrite, &to.Overwrite)
+	translate.MergeP(tr, tm, &r, "path", &from.Path, &to.Path)
 	return
 }
 

--- a/translate/set.go
+++ b/translate/set.go
@@ -93,15 +93,6 @@ func (ts TranslationSet) AddTranslation(from, to path.ContextPath) {
 	ts.Set[toString] = translation
 }
 
-// Shortcut for AddTranslation for identity translations
-func (ts TranslationSet) AddIdentity(paths ...string) {
-	for _, p := range paths {
-		from := path.New(ts.FromTag, p)
-		to := path.New(ts.ToTag, p)
-		ts.AddTranslation(from, to)
-	}
-}
-
 // AddFromCommonSource adds translations for all of the paths in to from a single common path. This is useful
 // if one part of a config generates a large struct and all of the large struct should map to one path in the
 // config being translated.

--- a/translate/translate_test.go
+++ b/translate/translate_test.go
@@ -328,35 +328,3 @@ func TestCustomTranslatorList(t *testing.T) {
 	assert.Equal(t, r.String(), "", "non-empty report")
 	assert.NoError(t, ts.DebugVerifyCoverage(&got), "incomplete TranslationSet coverage")
 }
-
-func TestAddIdentity(t *testing.T) {
-	ts := NewTranslationSet("1", "2")
-	ts.AddIdentity("foo", "bar")
-	expectedFoo := Translation{
-		From: path.New("1", "foo"),
-		To:   path.New("2", "foo"),
-	}
-	expectedBar := Translation{
-		From: path.New("1", "bar"),
-		To:   path.New("2", "bar"),
-	}
-	expectedFoo2 := Translation{
-		From: path.New("1", "pre", "foo"),
-		To:   path.New("2", "pre", "foo"),
-	}
-	expectedBar2 := Translation{
-		From: path.New("1", "pre", "bar"),
-		To:   path.New("2", "pre", "bar"),
-	}
-	ts2 := NewTranslationSet("1", "2")
-	ts2.MergeP("pre", ts)
-	ts3 := NewTranslationSet("1", "2")
-	ts3.Merge(ts.Prefix("pre"))
-
-	assert.Equal(t, ts.Set["$.foo"], expectedFoo, "foo not added correctly")
-	assert.Equal(t, ts.Set["$.bar"], expectedBar, "bar not added correctly")
-	assert.Equal(t, ts2.Set["$.pre.foo"], expectedFoo2, "foo not added correctly")
-	assert.Equal(t, ts3.Set["$.pre.bar"], expectedBar2, "bar not added correctly")
-	assert.Equal(t, ts3.Set["$.pre.foo"], expectedFoo2, "foo not added correctly")
-	assert.Equal(t, ts2.Set["$.pre.bar"], expectedBar2, "bar not added correctly")
-}


### PR DESCRIPTION
`AddIdentity()` doesn't know the field contents, so it can't skip adding a translation if the field is nil.  Switch to translating all fields via `translate.MergeP()`, rather than assigning directly and calling `AddIdentity()` afterward.  `MergeP()` is a better affordance than we had when `AddIdentity()` was introduced in 23146d3.

Delete `AddIdentity()` to remove the footgun.  This is an API break, but probably there are no out-of-tree callers.

